### PR TITLE
[Articker - 7] 페이지 모바일뷰 구현

### DIFF
--- a/src/components/Article/ArticleItem.tsx
+++ b/src/components/Article/ArticleItem.tsx
@@ -51,17 +51,12 @@ export default function NewsItem({ item }: { item: ArticleDataResponse }) {
                     </CompanyTag>
                   )}
               </CompanyContainer>
-              <DateContainer>
-                <Text size="12px" weight="normal" variant="grey">
-                  {item.publishedDate}
-                </Text>
-              </DateContainer>
-            </>
-          ) : (
-            <DateAndCompany>
-              <Text size="xs" weight="normal" variant="grey">
+              <Text size="12px" weight="normal" variant="grey">
                 {item.publishedDate}
               </Text>
+            </>
+          ) : (
+            <>
               {/* {item.sentiment !== null && (
                 <SentimentTag $color={sentimentInfo.color}>
                   <span>{sentimentInfo.emoji}</span>
@@ -70,21 +65,27 @@ export default function NewsItem({ item }: { item: ArticleDataResponse }) {
                   </Text>
                 </SentimentTag>
               )} */}
-              {item.shortCompanyNames?.slice(0, 5).map((company) => (
-                <CompanyTag key={company}>
-                  <Text size="xs" weight="normal">
-                    {company}
-                  </Text>
-                </CompanyTag>
-              ))}
-              {item.shortCompanyNames && item.shortCompanyNames.length > 5 && (
-                <CompanyTag>
-                  <Text size="xs" weight="normal">
-                    ...
-                  </Text>
-                </CompanyTag>
-              )}
-            </DateAndCompany>
+              <CompanyContainer>
+                {item.shortCompanyNames?.slice(0, 5).map((company) => (
+                  <CompanyTag key={company}>
+                    <Text size="xs" weight="normal">
+                      {company}
+                    </Text>
+                  </CompanyTag>
+                ))}
+                {item.shortCompanyNames &&
+                  item.shortCompanyNames.length > 4 && (
+                    <CompanyTag>
+                      <Text size="xs" weight="normal">
+                        ...
+                      </Text>
+                    </CompanyTag>
+                  )}
+              </CompanyContainer>
+              <Text size="xs" weight="normal" variant="grey">
+                {item.publishedDate}
+              </Text>
+            </>
           )}
         </TextContainer>
       </NewsContent>
@@ -158,22 +159,15 @@ const TitleText = styled(Text)`
   white-space: normal;
 `;
 
-const DateAndCompany = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding-top: 6px;
-`;
-
-const DateContainer = styled.div`
-  padding-top: 2px;
-`;
-
 const CompanyContainer = styled.div`
   display: flex;
   align-items: center;
   gap: 8px;
-  padding-top: 4px;
+  padding: 4px 0;
+
+  @media screen and (max-width: 768px) {
+    padding: 2px 0;
+  }
 `;
 
 const CompanyTag = styled.div`

--- a/src/components/Article/ArticleItem.tsx
+++ b/src/components/Article/ArticleItem.tsx
@@ -2,8 +2,10 @@ import styled from 'styled-components';
 import { Text } from '../common/typography/Text';
 import { ArticleDataResponse } from '@/types';
 import FallbackImage from '../common/Item/FallbackImage';
+import useIsMobile from '@/hooks/useIsMobile';
 
 export default function NewsItem({ item }: { item: ArticleDataResponse }) {
+  const isMobile = useIsMobile();
   const handleClick = () => {
     window.open(item.contentUrl, '_blank');
   };
@@ -27,29 +29,63 @@ export default function NewsItem({ item }: { item: ArticleDataResponse }) {
           <FallbackImage src={item.thumbnailUrl} alt={item.title} />
         </ImageContainer>
         <TextContainer>
-          <TitleText size="m" weight="bold">
+          <TitleText size={isMobile ? 'xs' : 'm'} weight="bold">
             {item.title}
           </TitleText>
-          <DateAndCompany>
-            <Text size="xs" weight="normal" variant="grey">
-              {item.publishedDate}
-            </Text>
-            {/* {item.sentiment !== null && (
-              <SentimentTag $color={sentimentInfo.color}>
-                <span>{sentimentInfo.emoji}</span>
-                <Text size="xs" weight="bold">
-                  {sentimentInfo.label}
+          {isMobile ? (
+            <>
+              <CompanyContainer>
+                {item.shortCompanyNames?.slice(0, 2).map((company) => (
+                  <CompanyTag key={company}>
+                    <Text size="12px" weight="normal">
+                      {company}
+                    </Text>
+                  </CompanyTag>
+                ))}
+                {item.shortCompanyNames &&
+                  item.shortCompanyNames.length > 2 && (
+                    <CompanyTag>
+                      <Text size="12px" weight="normal">
+                        ...
+                      </Text>
+                    </CompanyTag>
+                  )}
+              </CompanyContainer>
+              <DateContainer>
+                <Text size="12px" weight="normal" variant="grey">
+                  {item.publishedDate}
                 </Text>
-              </SentimentTag>
-            )} */}
-            {item.shortCompanyNames?.map((company) => (
-              <CompanyTag key={company}>
-                <Text size="xs" weight="normal">
-                  {company}
-                </Text>
-              </CompanyTag>
-            ))}
-          </DateAndCompany>
+              </DateContainer>
+            </>
+          ) : (
+            <DateAndCompany>
+              <Text size="xs" weight="normal" variant="grey">
+                {item.publishedDate}
+              </Text>
+              {/* {item.sentiment !== null && (
+                <SentimentTag $color={sentimentInfo.color}>
+                  <span>{sentimentInfo.emoji}</span>
+                  <Text size="xs" weight="bold">
+                    {sentimentInfo.label}
+                  </Text>
+                </SentimentTag>
+              )} */}
+              {item.shortCompanyNames?.slice(0, 5).map((company) => (
+                <CompanyTag key={company}>
+                  <Text size="xs" weight="normal">
+                    {company}
+                  </Text>
+                </CompanyTag>
+              ))}
+              {item.shortCompanyNames && item.shortCompanyNames.length > 5 && (
+                <CompanyTag>
+                  <Text size="xs" weight="normal">
+                    ...
+                  </Text>
+                </CompanyTag>
+              )}
+            </DateAndCompany>
+          )}
         </TextContainer>
       </NewsContent>
     </Wrapper>
@@ -71,8 +107,7 @@ const Wrapper = styled.div`
   }
 
   @media screen and (max-width: 768px) {
-    height: 100%;
-    gap: 12px;
+    padding: 12px 16px;
   }
 `;
 
@@ -80,11 +115,11 @@ const NewsContent = styled.div`
   position: relative;
   width: 90%;
   display: flex;
-  height: 100%;
   gap: 16px;
 
   @media screen and (max-width: 768px) {
-    gap: 8px;
+    gap: 12px;
+    align-items: center;
   }
 `;
 
@@ -96,13 +131,8 @@ const ImageContainer = styled.div`
   flex-shrink: 0;
 
   @media screen and (max-width: 768px) {
-    width: 60px;
+    width: 90px;
     height: 60px;
-  }
-
-  @media screen and (max-width: 430px) {
-    width: 70px;
-    height: 70px;
   }
 `;
 
@@ -111,6 +141,10 @@ const TextContainer = styled.div`
   flex-direction: column;
   gap: 6px;
   justify-content: center;
+
+  @media screen and (max-width: 768px) {
+    gap: 4px;
+  }
 `;
 
 const TitleText = styled(Text)`
@@ -129,10 +163,17 @@ const DateAndCompany = styled.div`
   align-items: center;
   gap: 8px;
   padding-top: 6px;
+`;
 
-  @media screen and (max-width: 768px) {
-    padding-top: 2px;
-  }
+const DateContainer = styled.div`
+  padding-top: 2px;
+`;
+
+const CompanyContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-top: 4px;
 `;
 
 const CompanyTag = styled.div`

--- a/src/components/Detail/RotationArticleItem.tsx
+++ b/src/components/Detail/RotationArticleItem.tsx
@@ -1,12 +1,14 @@
 import styled from 'styled-components';
 import { Text } from '../common/typography/Text';
 import { DetailArticleData } from '@/types';
+import useIsMobile from '@/hooks/useIsMobile';
 
 export default function RotationArticleItem({
   item,
 }: {
   item: DetailArticleData;
 }) {
+  const isMobile = useIsMobile();
   const handleClick = () => {
     return location.pathname === '/news';
   };
@@ -28,19 +30,23 @@ export default function RotationArticleItem({
       <NewsContent>
         <TextContainer>
           <TitleRow>
-            <TitleText size="m" weight="bold">
+            <TitleText size={isMobile ? 'xs' : 'm'} weight="bold">
               {item.headline}
             </TitleText>
             {item.sentiment !== null && (
               <SentimentTag $color={sentimentInfo.color}>
                 <span>{sentimentInfo.emoji}</span>
-                <Text size="xs" weight="bold">
+                <Text size={isMobile ? 'xxs' : 'xs'} weight="bold">
                   {sentimentInfo.label}
                 </Text>
               </SentimentTag>
             )}
           </TitleRow>
-          <DescriptionText size="xs" weight="normal" variant="grey">
+          <DescriptionText
+            size={isMobile ? 'xxs' : 'xs'}
+            weight="normal"
+            variant="grey"
+          >
             {item.reasoning}
           </DescriptionText>
         </TextContainer>
@@ -62,6 +68,10 @@ const Wrapper = styled.div`
 
   &:hover {
     background-color: #f4f7fc; // 추후 호버 시 해당 stock 필터링한 뉴스보드로 이동 추가
+  }
+
+  @media screen and (max-width: 768px) {
+    padding: 16px 16px 16px 20px;
   }
 
   @keyframes fadeIn {
@@ -98,12 +108,20 @@ const TextContainer = styled.div`
   flex-direction: column;
   gap: 12px;
   justify-content: flex-start;
+
+  @media screen and (max-width: 768px) {
+    gap: 8px;
+  }
 `;
 
 const TitleRow = styled.div`
   display: flex;
   align-items: center;
   gap: 10px;
+
+  @media screen and (max-width: 768px) {
+    gap: 6px;
+  }
 `;
 
 const TitleText = styled(Text)`
@@ -137,5 +155,14 @@ const SentimentTag = styled.div<{ $color: string }>`
 
   & > *:last-child {
     color: ${(props) => props.$color} !important;
+  }
+
+  @media screen and (max-width: 768px) {
+    padding: 4px 6px;
+    gap: 2px;
+
+    span {
+      font-size: 10px;
+    }
   }
 `;

--- a/src/components/Ticker/RealTimeTickerCharts.tsx
+++ b/src/components/Ticker/RealTimeTickerCharts.tsx
@@ -171,4 +171,8 @@ const Wrapper = styled.div`
   .apexcharts-area-series .apexcharts-series-0 .apexcharts-area {
     fill: url(#SvgjsLinearGradient1000) !important;
   }
+
+  @media screen and (max-width: 768px) {
+    padding: 0px;
+  }
 `;

--- a/src/components/Ticker/TickerCharts.tsx
+++ b/src/components/Ticker/TickerCharts.tsx
@@ -254,4 +254,8 @@ const Wrapper = styled.div<{ $sentiment: number }>`
   .apexcharts-area-series .apexcharts-series-0 .apexcharts-area {
     fill: url(#SvgjsLinearGradient1000) !important;
   }
+
+  @media screen and (max-width: 768px) {
+    padding: 0px;
+  }
 `;

--- a/src/components/Ticker/TickerItem.tsx
+++ b/src/components/Ticker/TickerItem.tsx
@@ -4,8 +4,10 @@ import { PredictionDataResponse } from '@/types';
 import { Link } from 'react-router-dom';
 import useGetVariant from '@/hooks/useGetVariant';
 import useGetSignSymbol from '@/hooks/useGetSignSymbol';
+import useIsMobile from '@/hooks/useIsMobile';
 
 export default function TickerItem({ item }: { item: PredictionDataResponse }) {
+  const isMobile = useIsMobile();
   const getVariant = useGetVariant(item.sentiment);
   const getSignSymbol = useGetSignSymbol(item.sentiment);
   const getSentiment =
@@ -13,18 +15,18 @@ export default function TickerItem({ item }: { item: PredictionDataResponse }) {
   return (
     <Wrapper to={`/ticker/${item.tickerId}`}>
       <TickerInfo>
-        <Text size="m" weight="bold">
+        <Text size={isMobile ? 's' : 'm'} weight="bold">
           {item.tickerCode}
         </Text>
-        <Text size="xs" weight="normal" variant="grey">
+        <Text size={isMobile ? 'xxs' : 'xs'} weight="normal" variant="grey">
           {item.shortCompanyName}
         </Text>
       </TickerInfo>
       <PriceInfo>
-        <Text size="m" weight="bold" variant={getVariant}>
+        <Text size={isMobile ? 's' : 'm'} weight="bold" variant={getVariant}>
           {getSignSymbol} {item.predictionStrategy} 추천
         </Text>
-        <Text size="xs" weight="bold" variant={getVariant}>
+        <Text size={isMobile ? 'xxs' : 'xs'} weight="bold" variant={getVariant}>
           {getSentiment} 기사 {item.articleCount}건
         </Text>
       </PriceInfo>
@@ -42,6 +44,10 @@ const Wrapper = styled(Link)`
   cursor: pointer;
   &:hover {
     background-color: #f4f7fc;
+  }
+
+  @media screen and (max-width: 768px) {
+    padding: 18px 28px;
   }
 `;
 const TickerInfo = styled.div`

--- a/src/components/common/Layout/Footer.tsx
+++ b/src/components/common/Layout/Footer.tsx
@@ -14,7 +14,7 @@ export default function Footer() {
               대구광역시 북구 대학로 80
             </Text>
             <Text size="xxs" weight="normal" variant="#979797">
-              finn.official@gmail.com
+              articker.kr.official@gmail.com
             </Text>
           </CompanyInfo>
         </FooterInfo>

--- a/src/components/common/Layout/MainHeader.tsx
+++ b/src/components/common/Layout/MainHeader.tsx
@@ -51,10 +51,19 @@ const HeaderContainer = styled.header`
   align-items: center;
   justify-content: space-between;
   padding: 0 20px;
+
+  @media screen and (max-width: 768px) {
+    width: 90%;
+    padding: 0 16px;
+  }
 `;
 const LogoWrapper = styled.img`
   width: 100px;
   cursor: pointer;
+
+  @media screen and (max-width: 768px) {
+    width: 80px;
+  }
 `;
 const NavButton = styled.button`
   background: none;

--- a/src/components/common/Layout/MainHeader.tsx
+++ b/src/components/common/Layout/MainHeader.tsx
@@ -26,7 +26,7 @@ export const MainHeader = forwardRef<HTMLDivElement, HeaderProps>(
         <NavButton
           onClick={() =>
             window.open(
-              'https://docs.google.com/forms/d/e/1FAIpQLSdAmupkmABBlR6YZN_RxBjRGxUVnSkpEOvBWKTHvl04wQCXxA/viewform?usp=dialog',
+              'https://docs.google.com/forms/d/e/1FAIpQLSeXlCSj7un7J5cnisJRaQE_RTpEqSjcnDhVHv3ZrCOBj5-I3A/viewform?usp=dialog',
               '_blank'
             )
           }

--- a/src/components/common/Layout/MainHeader.tsx
+++ b/src/components/common/Layout/MainHeader.tsx
@@ -23,6 +23,16 @@ export const MainHeader = forwardRef<HTMLDivElement, HeaderProps>(
           alt="Articker Logo"
           onClick={() => navigate('/')}
         />
+        <NavButton
+          onClick={() =>
+            window.open(
+              'https://docs.google.com/forms/d/e/1FAIpQLSdAmupkmABBlR6YZN_RxBjRGxUVnSkpEOvBWKTHvl04wQCXxA/viewform?usp=dialog',
+              '_blank'
+            )
+          }
+        >
+          피드백 남기기
+        </NavButton>
       </HeaderContainer>
     );
   }
@@ -39,9 +49,22 @@ const HeaderContainer = styled.header`
   width: 100%;
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  padding: 0 20px;
 `;
 const LogoWrapper = styled.img`
   width: 100px;
-  margin-left: 20px;
   cursor: pointer;
+`;
+const NavButton = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  color: #292929;
+
+  &:hover {
+    color: #2d70d3;
+  }
 `;

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+
+const MOBILE_WIDTH_THRESHOLD = 768;
+
+export default function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(
+    typeof window !== 'undefined'
+      ? window.innerWidth <= MOBILE_WIDTH_THRESHOLD
+      : false
+  );
+
+  useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth <= MOBILE_WIDTH_THRESHOLD);
+    };
+
+    checkMobile();
+    window.addEventListener('resize', checkMobile);
+    return () => window.removeEventListener('resize', checkMobile);
+  }, []);
+
+  return isMobile;
+}

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -15,6 +15,7 @@ import { useState, useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { Paragraph } from '@/components/common/typography/Paragraph';
 import RotationArticleItem from '@/components/Detail/RotationArticleItem';
+import useIsMobile from '@/hooks/useIsMobile';
 
 export default function DetailPage() {
   const { id } = useParams() as { id: string };
@@ -24,6 +25,7 @@ export default function DetailPage() {
   const [showRefreshTooltip, setShowRefreshTooltip] = useState(false);
   const [currentNewsIndex, setCurrentNewsIndex] = useState(0);
   const queryClient = useQueryClient();
+  const isMobile = useIsMobile();
 
   const {
     data: tickerResponse,
@@ -101,74 +103,79 @@ export default function DetailPage() {
     <Wrapper>
       <TickerTitle>
         <CompanyInfo>
-          <Text size="l" weight="bold">
+          <Text size={isMobile ? 'm' : 'l'} weight="bold">
             {tickerData.shortCompanyName}
           </Text>
-          <Text size="s" weight="normal" variant="grey">
+          <Text size={isMobile ? 'xs' : 's'} weight="normal" variant="grey">
             {tickerData.tickerCode}
           </Text>
         </CompanyInfo>
-        <ScoreTitleContainer>
-          <Paragraph size="s" weight="bold">
-            종목 점수
-          </Paragraph>
-          <TooltipContainer
-            onMouseEnter={() => setShowTooltip(true)}
-            onMouseLeave={() => setShowTooltip(false)}
-          >
-            <BsFillQuestionCircleFill size={16} color="#BCC7D9" />
-            {showTooltip && (
-              <Tooltip>
-                수집된 기사의 감정(긍정/부정) 비율에 추세를 반영하여 계산된
-                점수입니다.
-              </Tooltip>
-            )}
-          </TooltipContainer>
-        </ScoreTitleContainer>
+        {!isMobile && (
+          <ScoreTitleContainer>
+            <Paragraph size={isMobile ? 'xs' : 's'} weight="bold">
+              종목 점수
+            </Paragraph>
+            <TooltipContainer
+              onMouseEnter={() => setShowTooltip(true)}
+              onMouseLeave={() => setShowTooltip(false)}
+            >
+              <BsFillQuestionCircleFill
+                size={isMobile ? 14 : 16}
+                color="#BCC7D9"
+              />
+              {showTooltip && (
+                <Tooltip>
+                  수집된 기사의 감정(긍정/부정) 비율에 추세를 반영하여 계산된
+                  점수입니다.
+                </Tooltip>
+              )}
+            </TooltipContainer>
+          </ScoreTitleContainer>
+        )}
       </TickerTitle>
       <TickerInfo>
         <InfoGrid>
           <InfoItem>
-            <Text size="xs" weight="normal">
+            <Text size={isMobile ? 'xxs' : 'xs'} weight="normal">
               시가
             </Text>
-            <Text size="xs" weight="normal" variant="grey">
+            <Text size={isMobile ? 'xxs' : 'xs'} weight="normal" variant="grey">
               $ {tickerData.detailData.open}
             </Text>
           </InfoItem>
 
           <InfoItem>
-            <Text size="xs" weight="normal">
+            <Text size={isMobile ? 'xxs' : 'xs'} weight="normal">
               종가
             </Text>
-            <Text size="xs" weight="normal" variant="grey">
+            <Text size={isMobile ? 'xxs' : 'xs'} weight="normal" variant="grey">
               $ {tickerData.detailData.close}
             </Text>
           </InfoItem>
 
           <InfoItem>
-            <Text size="xs" weight="normal">
+            <Text size={isMobile ? 'xxs' : 'xs'} weight="normal">
               고가
             </Text>
-            <Text size="xs" weight="normal" variant="grey">
+            <Text size={isMobile ? 'xxs' : 'xs'} weight="normal" variant="grey">
               $ {tickerData.detailData.high}
             </Text>
           </InfoItem>
 
           <InfoItem>
-            <Text size="xs" weight="normal">
+            <Text size={isMobile ? 'xxs' : 'xs'} weight="normal">
               저가
             </Text>
-            <Text size="xs" weight="normal" variant="grey">
+            <Text size={isMobile ? 'xxs' : 'xs'} weight="normal" variant="grey">
               $ {tickerData.detailData.low}
             </Text>
           </InfoItem>
 
           <InfoItem>
-            <Text size="xs" weight="normal">
+            <Text size={isMobile ? 'xxs' : 'xs'} weight="normal">
               거래량
             </Text>
-            <Text size="xs" weight="normal" variant="grey">
+            <Text size={isMobile ? 'xxs' : 'xs'} weight="normal" variant="grey">
               {tickerData.detailData.volume.toLocaleString()}주
             </Text>
           </InfoItem>
@@ -178,14 +185,46 @@ export default function DetailPage() {
             </Text>
           </ItemDate>
         </InfoGrid>
+        {!isMobile && (
+          <ScoreGaugeChart
+            value={tickerData.sentimentScore}
+            maxValue={100}
+            title="점수"
+            predictionStrategy={tickerData.predictionStrategy}
+          />
+        )}
+      </TickerInfo>
+      {isMobile && (
+        <ScoreTitleContainer>
+          <Paragraph size={isMobile ? 'xs' : 's'} weight="bold">
+            종목 점수
+          </Paragraph>
+          <TooltipContainer
+            onMouseEnter={() => setShowTooltip(true)}
+            onMouseLeave={() => setShowTooltip(false)}
+          >
+            <BsFillQuestionCircleFill
+              size={isMobile ? 14 : 16}
+              color="#BCC7D9"
+            />
+            {showTooltip && (
+              <Tooltip>
+                수집된 기사의 감정(긍정/부정) 비율에 추세를 반영하여 계산된
+                점수입니다.
+              </Tooltip>
+            )}
+          </TooltipContainer>
+        </ScoreTitleContainer>
+      )}
+      {isMobile && (
         <ScoreGaugeChart
           value={tickerData.sentimentScore}
           maxValue={100}
           title="점수"
           predictionStrategy={tickerData.predictionStrategy}
         />
-      </TickerInfo>
-      <Paragraph size="s" weight="bold">
+      )}
+      <Paragraph size={isMobile ? 'xs' : 's'} weight="bold">
         실제 주가
       </Paragraph>
       <PeriodSelectorContainer>
@@ -209,7 +248,7 @@ export default function DetailPage() {
         </PeriodSelector>
         <RefreshContainer>
           <RefreshButton onClick={handleRefresh} variant="grey" size="small">
-            <IoMdRefresh size={16} />
+            <IoMdRefresh size={isMobile ? 14 : 16} />
           </RefreshButton>
           {showRefreshTooltip && (
             <RefreshTooltip>최신 상태로 업데이트 되었습니다!</RefreshTooltip>
@@ -231,7 +270,7 @@ export default function DetailPage() {
       {tickerData?.detailData.article &&
         tickerData.detailData.article.length > 0 && (
           <>
-            <Paragraph size="s" weight="bold">
+            <Paragraph size={isMobile ? 'xs' : 's'} weight="bold">
               실시간 기사
             </Paragraph>
             <RotationArticleItem
@@ -249,11 +288,23 @@ const Wrapper = styled.div`
   flex-direction: column;
   gap: 20px;
   padding: 16px 0;
+
+  @media screen and (max-width: 768px) {
+    width: 80%;
+    gap: 18px;
+    padding: 12px 0;
+  }
 `;
 const TickerTitle = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: baseline;
+
+  @media screen and (max-width: 768px) {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
 `;
 
 const CompanyInfo = styled.div`
@@ -261,12 +312,22 @@ const CompanyInfo = styled.div`
   align-items: baseline;
   gap: 8px;
   margin-right: 20px;
+
+  @media screen and (max-width: 768px) {
+    gap: 6px;
+    margin-right: 2px;
+  }
 `;
 
 const ScoreTitleContainer = styled.div`
   display: flex;
   gap: 6px;
   margin-right: 180px;
+
+  @media screen and (max-width: 768px) {
+    margin-right: 10px;
+    gap: 4px;
+  }
 `;
 
 const TooltipContainer = styled.div`
@@ -313,6 +374,11 @@ const TickerInfo = styled.div`
   align-items: flex-start;
   gap: 20px;
   padding: 8px 0px 12px 0px;
+
+  @media screen and (max-width: 768px) {
+    flex-direction: column;
+    gap: 16px;
+  }
 `;
 const InfoGrid = styled.div`
   display: grid;
@@ -322,6 +388,13 @@ const InfoGrid = styled.div`
   gap: 24px;
   padding: 24px 0 0 0;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+
+  @media screen and (max-width: 768px) {
+    width: 90%;
+    max-width: 300px;
+    gap: 20px;
+    padding: 16px 0 0 0;
+  }
 `;
 
 const InfoItem = styled.div`
@@ -340,16 +413,34 @@ const InfoItem = styled.div`
   &:nth-child(6) {
     justify-content: flex-end;
   }
+
+  @media screen and (max-width: 768px) {
+    margin: 0px 20px;
+
+    &:nth-child(5) {
+      gap: 16px;
+      margin: 0 0 0 20px;
+    }
+  }
 `;
 const ItemDate = styled.div`
   grid-column: span 2;
   text-align: right;
   margin-right: 26px;
   margin-top: -40px;
+
+  @media screen and (max-width: 768px) {
+    margin-right: 20px;
+    margin-top: -32px;
+  }
 `;
 const PeriodSelector = styled.div`
   display: flex;
   gap: 12px;
+
+  @media screen and (max-width: 768px) {
+    gap: 8px;
+  }
 `;
 const PeriodButton = styled.button<{ $active: boolean }>`
   padding: 8px 16px;
@@ -365,6 +456,11 @@ const PeriodButton = styled.button<{ $active: boolean }>`
   &:hover {
     border-color: #47c8d9;
     background-color: ${(props) => (props.$active ? '#47c8d9' : '#f0f9fa')};
+  }
+
+  @media screen and (max-width: 768px) {
+    padding: 6px 12px;
+    font-size: 12px;
   }
 `;
 
@@ -385,6 +481,11 @@ const LiveButton = styled.button<{ $active: boolean }>`
     border-color: #47c8d9;
     background-color: ${(props) => (props.$active ? '#47c8d9' : '#f0f9fa')};
   }
+
+  @media screen and (max-width: 768px) {
+    padding: 6px 6px 6px 12px;
+    font-size: 12px;
+  }
 `;
 
 const LiveDot = styled.div`
@@ -395,6 +496,12 @@ const LiveDot = styled.div`
   background-color: #e74c3c;
   border-radius: 50%;
   animation: pulse 2s infinite;
+
+  @media screen and (max-width: 768px) {
+    width: 4px;
+    height: 4px;
+    top: -6px;
+  }
 
   @keyframes pulse {
     0% {
@@ -433,6 +540,11 @@ const RefreshButton = styled(Button)`
       transition: transform 0.3s ease;
     }
   }
+
+  @media screen and (max-width: 768px) {
+    width: 34px;
+    height: 28px;
+  }
 `;
 
 const RefreshTooltip = styled(Tooltip)`
@@ -448,22 +560,47 @@ const RefreshTooltip = styled(Tooltip)`
     display: none;
   }
 
-  @keyframes tooltipSlideLeft {
-    0% {
-      opacity: 0;
-      transform: translateX(20px);
+  @media screen and (max-width: 768px) {
+    right: 24px;
+    top: 34px;
+    animation: tooltipSlideBottom 3s ease-in-out forwards;
+
+    @keyframes tooltipSlideLeft {
+      0% {
+        opacity: 0;
+        transform: translateX(20px);
+      }
+      15% {
+        opacity: 1;
+        transform: translateX(0);
+      }
+      85% {
+        opacity: 1;
+        transform: translateX(0);
+      }
+      100% {
+        opacity: 0;
+        transform: translateX(-20px);
+      }
     }
-    15% {
-      opacity: 1;
-      transform: translateX(0);
-    }
-    85% {
-      opacity: 1;
-      transform: translateX(0);
-    }
-    100% {
-      opacity: 0;
-      transform: translateX(-20px);
+
+    @keyframes tooltipSlideBottom {
+      0% {
+        opacity: 0;
+        transform: translateY(-20px);
+      }
+      15% {
+        opacity: 1;
+        transform: translateY(0);
+      }
+      85% {
+        opacity: 1;
+        transform: translateY(0);
+      }
+      100% {
+        opacity: 0;
+        transform: translateY(20px);
+      }
     }
   }
 `;

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -209,8 +209,8 @@ export default function DetailPage() {
             />
             {showTooltip && (
               <Tooltip>
-                수집된 기사의 감정(긍정/부정) 비율에 추세를 반영하여 계산된
-                점수입니다.
+                수집된 기사의 감정(긍정/부정) 비율에
+                <br /> 추세를 반영하여 계산된 점수입니다.
               </Tooltip>
             )}
           </TooltipContainer>
@@ -367,6 +367,10 @@ const Tooltip = styled.div`
     border: 7px solid transparent;
     border-top-color: #ddd;
     margin-top: 1px;
+  }
+
+  @media screen and (max-width: 768px) {
+    line-height: 1.4;
   }
 `;
 const TickerInfo = styled.div`

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -290,7 +290,7 @@ const Wrapper = styled.div`
   padding: 16px 0;
 
   @media screen and (max-width: 768px) {
-    width: 80%;
+    width: 84%;
     gap: 18px;
     padding: 12px 0;
   }

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -54,7 +54,7 @@ const Wrapper = styled.div`
   padding: 16px 0;
 
   @media screen and (max-width: 768px) {
-    width: 80%;
+    width: 84%;
     gap: 30px;
     padding: 12px 0;
   }

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -6,10 +6,12 @@ import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import { useGetPopularTickers } from '@/api/hooks/useGetInfiniteTickerList';
 import MarketStatusBanner from '@/components/common/Banner/MarketStatusBanner';
+import useIsMobile from '@/hooks/useIsMobile';
 
 export default function MainPage() {
   const navigate = useNavigate();
   const { data: popularData } = useGetPopularTickers();
+  const isMobile = useIsMobile();
   return (
     <Wrapper>
       <SearchBar />
@@ -17,10 +19,14 @@ export default function MainPage() {
         <MarketStatusBanner />
         <TickerTitle>
           <Left>
-            <Paragraph size="m" weight="bold">
+            <Paragraph size={isMobile ? 'xs' : 'm'} weight="bold">
               한국인이 가장 좋아하는 종목 Top5
             </Paragraph>
-            <Paragraph size="xxs" weight="normal" variant="grey">
+            <Paragraph
+              size={isMobile ? '12px' : 'xxs'}
+              weight="normal"
+              variant="grey"
+            >
               여러분이 가장 좋아하는 종목을 예측했어요!
             </Paragraph>
           </Left>
@@ -46,6 +52,12 @@ const Wrapper = styled.div`
   align-items: center;
   gap: 36px;
   padding: 16px 0;
+
+  @media screen and (max-width: 768px) {
+    width: 80%;
+    gap: 30px;
+    padding: 12px 0;
+  }
 `;
 const TickerSection = styled.div`
   width: 100%;
@@ -63,6 +75,12 @@ const MoreBtn = styled.button`
   &:hover {
     text-decoration: underline;
   }
+
+  @media screen and (max-width: 768px) {
+    padding: 6px 8px;
+    font-size: 12px;
+    align-items: center;
+  }
 `;
 
 const TickerTitle = styled.div`
@@ -70,9 +88,17 @@ const TickerTitle = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: end;
+
+  @media screen and (max-width: 768px) {
+    padding-bottom: 18px;
+  }
 `;
 const Left = styled.div`
   display: flex;
   flex-direction: column;
   gap: 6px;
+
+  @media screen and (max-width: 768px) {
+    gap: 4px;
+  }
 `;

--- a/src/pages/NewsBoard/index.tsx
+++ b/src/pages/NewsBoard/index.tsx
@@ -112,7 +112,7 @@ const Wrapper = styled.div`
   padding: 16px 0;
 
   @media screen and (max-width: 768px) {
-    width: 80%;
+    width: 84%;
     gap: 40px;
     padding: 12px 0;
   }

--- a/src/pages/NewsBoard/index.tsx
+++ b/src/pages/NewsBoard/index.tsx
@@ -110,12 +110,23 @@ const Wrapper = styled.div`
   flex-direction: column;
   gap: 50px;
   padding: 16px 0;
+
+  @media screen and (max-width: 768px) {
+    width: 80%;
+    gap: 40px;
+    padding: 12px 0;
+  }
 `;
 
 const FilterContainer = styled.div`
   display: flex;
   gap: 20px;
   margin-top: -30px;
+
+  @media screen and (max-width: 768px) {
+    margin-top: -32px;
+    margin-bottom: -10px;
+  }
 `;
 
 const FilterTab = styled.button<{ $active: boolean }>`
@@ -127,6 +138,11 @@ const FilterTab = styled.button<{ $active: boolean }>`
   background: none;
   cursor: pointer;
   color: ${(props) => (props.$active ? '#2d70d3' : '#8c8c8c')};
+
+  @media screen and (max-width: 768px) {
+    padding: 10px 20px;
+    font-size: 14px;
+  }
 `;
 
 const ErrorMessage = styled.div`

--- a/src/pages/Ticker/index.tsx
+++ b/src/pages/Ticker/index.tsx
@@ -62,7 +62,7 @@ const Wrapper = styled.div`
   gap: 36px;
 
   @media screen and (max-width: 768px) {
-    width: 80%;
+    width: 84%;
     gap: 30px;
     padding: 12px 0;
   }

--- a/src/pages/Ticker/index.tsx
+++ b/src/pages/Ticker/index.tsx
@@ -4,6 +4,7 @@ import { useGetPopularTickers } from '@/api/hooks/useGetInfiniteTickerList';
 import { useEffect, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 import Loading from '@/components/common/Layout/Loading';
+import SearchBar from '@/components/common/SearchBar';
 
 export default function TickerPage() {
   const [isInitialLoad, setIsInitialLoad] = useState(true);
@@ -46,6 +47,7 @@ export default function TickerPage() {
 
   return (
     <Wrapper>
+      <SearchBar />
       <TickerList items={allTickers} />
       <div ref={ref} style={{ height: '50px' }} />
       {isFetchingNextPage && <Loading />}
@@ -57,6 +59,13 @@ const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   padding: 16px 0;
+  gap: 36px;
+
+  @media screen and (max-width: 768px) {
+    width: 80%;
+    gap: 30px;
+    padding: 12px 0;
+  }
 `;
 
 const ErrorMessage = styled.div`


### PR DESCRIPTION
- [x] 모바일뷰인지 구분하는 `useIsMobile` 훅 추가
- [x] 메인페이지 모바일뷰 코드 추가
- [x] 뉴스보드 페이지 모바일뷰 코드 추가
- [x] 종목 상세 페이지 모바일뷰 코드 추가
- [x] 서비스 이메일 수정
- [x] 헤더에 피드백 남기기 버튼 추가 및 모바일뷰 적용
- [x] `ArticleItem`의 `publishDate`가 `companyTag` 아래로 오도록 수정
- [x] 모바일뷰 페이지 width 간격 더 늘리기
- [x] detail 페이지에서 모바일이면 tooltip 줄간격 추가
- [x] 실제 주가 그래프 - 모바일이면 padding 없애기
- [x] 피드백 폼 링크 변경 