### PR TITLE
[ Articker - 9 ] 배포 후 첫 번째 피드백 반영

### DIFF
--- a/src/api/hooks/useGetFilterTickerList.ts
+++ b/src/api/hooks/useGetFilterTickerList.ts
@@ -1,12 +1,12 @@
 import { fetchInstance } from '@/api/instance';
-import { ApiResponse, ArticleTickerFilteringResponse } from '@/types';
+import { ApiResponse, ArticleTickerListData } from '@/types';
 import { useQuery } from '@tanstack/react-query';
 
 export const getFilterTickerListPath = () => `/api/v1/article/ticker-list`;
 export const getFilterTickerList = async () => {
-  const response = await fetchInstance.get<
-    ApiResponse<ArticleTickerFilteringResponse[]>
-  >(getFilterTickerListPath());
+  const response = await fetchInstance.get<ApiResponse<ArticleTickerListData>>(
+    getFilterTickerListPath()
+  );
   return response.data;
 };
 

--- a/src/api/hooks/useGetFilterTickerList.ts
+++ b/src/api/hooks/useGetFilterTickerList.ts
@@ -1,0 +1,19 @@
+import { fetchInstance } from '@/api/instance';
+import { ApiResponse, ArticleTickerFilteringResponse } from '@/types';
+import { useQuery } from '@tanstack/react-query';
+
+export const getFilterTickerListPath = () => `/api/v1/article/ticker-list`;
+export const getFilterTickerList = async () => {
+  const response = await fetchInstance.get<
+    ApiResponse<ArticleTickerFilteringResponse[]>
+  >(getFilterTickerListPath());
+  return response.data;
+};
+
+export const useGetFilterTickerList = () => {
+  return useQuery({
+    queryKey: ['filterTickerList'],
+    queryFn: getFilterTickerList,
+    staleTime: 1000 * 60 * 60,
+  });
+};

--- a/src/api/hooks/useGetInfiniteArticleList.ts
+++ b/src/api/hooks/useGetInfiniteArticleList.ts
@@ -6,6 +6,7 @@ import { ArticleListData, PageableData } from '@/types';
 interface ArticleListParams {
   filter: 'all' | 'positive' | 'negative';
   sort: 'recent';
+  tickerId?: string;
 }
 
 export const getInfiniteArticleListPath = () => `/api/v1/article`;
@@ -14,12 +15,17 @@ export const getInfiniteArticleList = async ({
   filter,
   sort,
   page,
+  tickerId,
 }: ArticleListParams & { page: number }) => {
   const params = new URLSearchParams({
     filter,
     sort,
     page: page.toString(),
   });
+
+  if (tickerId) {
+    params.append('tickerId', tickerId);
+  }
 
   const response = await fetchInstance.get<PageableData<ArticleListData>>(
     `${getInfiniteArticleListPath()}?${params}`
@@ -30,11 +36,12 @@ export const getInfiniteArticleList = async ({
 export const useGetInfiniteArticleList = ({
   filter,
   sort,
+  tickerId,
 }: ArticleListParams) => {
   return useInfiniteQuery({
-    queryKey: ['articleList', { filter, sort }],
+    queryKey: ['articleList', { filter, sort, tickerId }],
     queryFn: ({ pageParam = 0 }) =>
-      getInfiniteArticleList({ filter, sort, page: pageParam }),
+      getInfiniteArticleList({ filter, sort, page: pageParam, tickerId }),
     initialPageParam: 0,
     getNextPageParam: (lastPage, allPages) => {
       if (lastPage.content.hasNext) {

--- a/src/api/hooks/useGetInfiniteArticleList.ts
+++ b/src/api/hooks/useGetInfiniteArticleList.ts
@@ -6,7 +6,7 @@ import { ArticleListData, PageableData } from '@/types';
 interface ArticleListParams {
   filter: 'all' | 'positive' | 'negative';
   sort: 'recent';
-  tickerId?: string;
+  tickerCode?: string[];
 }
 
 export const getInfiniteArticleListPath = () => `/api/v1/article`;
@@ -15,7 +15,7 @@ export const getInfiniteArticleList = async ({
   filter,
   sort,
   page,
-  tickerId,
+  tickerCode,
 }: ArticleListParams & { page: number }) => {
   const params = new URLSearchParams({
     filter,
@@ -23,8 +23,10 @@ export const getInfiniteArticleList = async ({
     page: page.toString(),
   });
 
-  if (tickerId) {
-    params.append('tickerId', tickerId);
+  if (tickerCode && tickerCode.length > 0) {
+    tickerCode.forEach((code) => {
+      params.append('tickerCode', code);
+    });
   }
 
   const response = await fetchInstance.get<PageableData<ArticleListData>>(
@@ -36,12 +38,12 @@ export const getInfiniteArticleList = async ({
 export const useGetInfiniteArticleList = ({
   filter,
   sort,
-  tickerId,
+  tickerCode,
 }: ArticleListParams) => {
   return useInfiniteQuery({
-    queryKey: ['articleList', { filter, sort, tickerId }],
+    queryKey: ['articleList'],
     queryFn: ({ pageParam = 0 }) =>
-      getInfiniteArticleList({ filter, sort, page: pageParam, tickerId }),
+      getInfiniteArticleList({ filter, sort, page: pageParam, tickerCode }),
     initialPageParam: 0,
     getNextPageParam: (lastPage, allPages) => {
       if (lastPage.content.hasNext) {

--- a/src/api/hooks/useGetInfiniteTickerList.ts
+++ b/src/api/hooks/useGetInfiniteTickerList.ts
@@ -39,15 +39,3 @@ export const useGetInfiniteTickerList = ({ sort }: GetTickerListParams) => {
     staleTime: 1000 * 60 * 5,
   });
 };
-
-export const useGetPopularTickers = () => {
-  return useGetInfiniteTickerList({ sort: 'popular' });
-};
-
-export const useGetRisingTickers = () => {
-  return useGetInfiniteTickerList({ sort: 'upward' });
-};
-
-export const useGetFallingTickers = () => {
-  return useGetInfiniteTickerList({ sort: 'downward' });
-};

--- a/src/components/Article/FilterChip/index.tsx
+++ b/src/components/Article/FilterChip/index.tsx
@@ -1,0 +1,82 @@
+import styled from 'styled-components';
+import { IoClose } from 'react-icons/io5';
+import { Text } from '@/components/common/typography/Text';
+
+type Props = {
+  selectedTickers: { tickerCode: string; shortCompanyName: string }[];
+  onClearTicker: (tickerCode: string) => void;
+};
+
+export default function FilterChip({ selectedTickers, onClearTicker }: Props) {
+  return (
+    <Container>
+      {selectedTickers.map((ticker) => (
+        <ChipButton key={ticker.tickerCode}>
+          <Text size="xxs" weight="normal" variant="#305675">
+            {ticker.shortCompanyName}
+          </Text>
+          <ClearButton
+            aria-label="종목 칩 제거"
+            onClick={() => onClearTicker(ticker.tickerCode)}
+          >
+            <IoClose size={14} />
+          </ClearButton>
+        </ChipButton>
+      ))}
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 10px;
+  overflow-x: auto;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  & > * {
+    flex-shrink: 0;
+  }
+
+  @media screen and (max-width: 768px) {
+    padding: 0;
+    gap: 8px;
+    margin: 14px 0;
+  }
+`;
+
+const ChipButton = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: 'space-between';
+  padding: 4px 10px 4px 18px;
+  height: 24px;
+  border-radius: 18px;
+  background-color: #dbeeff;
+  color: #898989;
+
+  @media screen and (max-width: 768px) {
+    padding: 4px 10px 4px 14px;
+    font-size: 14px;
+    height: 20px;
+  }
+`;
+
+const ClearButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 2px;
+  padding: 2px;
+  border-radius: 50%;
+  cursor: pointer;
+  background: none;
+  border: none;
+  color: inherit;
+
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.05);
+  }
+`;

--- a/src/components/Article/FilterDrowndown/DropdownItem.tsx
+++ b/src/components/Article/FilterDrowndown/DropdownItem.tsx
@@ -1,0 +1,43 @@
+import styled from 'styled-components';
+
+interface DropdownItemProps {
+  label: string;
+  onClick: () => void;
+  isFiltered?: boolean;
+  children?: React.ReactNode;
+}
+
+export default function DropdownItem({
+  label,
+  onClick,
+  children,
+  isFiltered,
+}: DropdownItemProps) {
+  return (
+    <DropdownItems onClick={onClick} $isFiltered={isFiltered}>
+      {label}
+      {children}
+    </DropdownItems>
+  );
+}
+
+const DropdownItems = styled.div<{
+  $isFiltered?: boolean;
+}>`
+  padding: 10px 16px;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  background-color: ${({ $isFiltered }) =>
+    $isFiltered ? '#edf5fd' : '#ffffff'};
+
+  &:hover {
+    background-color: ${({ $isFiltered }) =>
+      $isFiltered ? '#e3edf7' : '#f0f0f0'};
+  }
+
+  @media screen and (max-width: 768px) {
+    padding: 12px 12px;
+    font-size: 14px;
+  }
+`;

--- a/src/components/Article/FilterDrowndown/DropdownMenu.tsx
+++ b/src/components/Article/FilterDrowndown/DropdownMenu.tsx
@@ -1,0 +1,224 @@
+import { useMemo, useRef, useState } from 'react';
+import { FaSearch } from 'react-icons/fa';
+import { RiMenuFill } from 'react-icons/ri';
+import styled from 'styled-components';
+import DropdownItem from './DropdownItem';
+import useClickOutside from '@/hooks/useClickOutside';
+
+interface Option {
+  label: string;
+  id: string;
+}
+
+export interface DropdownMenuProps {
+  options: Option[];
+  onChange: (value: { id: string }) => void;
+  placeholder?: string;
+  width: number;
+  selectedOptions?: string[];
+}
+
+export default function DropdownMenu({
+  options,
+  onChange,
+  placeholder = '',
+  width,
+  selectedOptions,
+}: DropdownMenuProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const [searchTerm, setSearchTerm] = useState('');
+  useClickOutside([dropdownRef as React.RefObject<HTMLElement>], () => {
+    setIsOpen(false);
+  });
+
+  const filteredOptions = useMemo(() => {
+    try {
+      return (
+        options?.filter((option) => {
+          if (!searchTerm) return true; // 모든 항목 반환
+          return option?.label
+            ?.toLowerCase()
+            .includes(searchTerm.toLowerCase());
+        }) || []
+      );
+    } catch {
+      return [];
+    }
+  }, [options, searchTerm]);
+
+  const handleOptionClick = (option: Option) => {
+    onChange({
+      id: option.id,
+    });
+    setIsOpen(false);
+  };
+
+  const handleSearchInputChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setSearchTerm(event.target.value);
+  };
+
+  const handleDropdownToggle = () => {
+    if (isOpen) {
+      setIsOpen(false);
+      setSearchTerm('');
+    } else {
+      setIsOpen(true);
+      setSearchTerm('');
+    }
+  };
+
+  return (
+    <DropdownContainer ref={dropdownRef} $width={width}>
+      <DropdownButton
+        aria-label="종목 선택 드롭다운"
+        $isOpen={isOpen}
+        onClick={handleDropdownToggle}
+      >
+        <RiMenuFill color="#2d70d3" />
+        {placeholder}
+      </DropdownButton>
+      {isOpen && (
+        <DropdownMenuContainer>
+          <SearchInputContainer>
+            <SearchInput
+              placeholder="검색"
+              value={searchTerm}
+              onChange={handleSearchInputChange}
+            />
+            <SearchIcon />
+          </SearchInputContainer>
+          <ItemContainer>
+            {filteredOptions.map((option) => (
+              <DropdownItem
+                key={option.label}
+                label={option.label}
+                onClick={() => handleOptionClick(option)}
+                isFiltered={selectedOptions?.includes(option.id) || false}
+              />
+            ))}
+          </ItemContainer>
+        </DropdownMenuContainer>
+      )}
+    </DropdownContainer>
+  );
+}
+
+const DropdownContainer = styled.div<{ $width: number }>`
+  position: relative;
+  height: 100%;
+  width: ${({ $width }) => `${$width}px`};
+  align-items: center;
+  align-content: center;
+
+  @media screen and (max-width: 768px) {
+    width: 100%;
+  }
+`;
+
+const DropdownButton = styled.button<{ $isOpen: boolean }>`
+  width: 100%;
+  height: 100%;
+  border: none;
+  background-color: ${({ $isOpen }) => ($isOpen ? '#f2f2f2' : '#ffffff')};
+  border-radius: 10px;
+  display: flex;
+  color: #333333;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 16px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  gap: 4px;
+
+  &:hover {
+    background-color: #f2f2f2;
+    border: none;
+  }
+
+  @media screen and (max-width: 768px) {
+    padding: 0px 4px;
+    font-size: 14px;
+    color: grey;
+    gap: 0px;
+  }
+`;
+
+const DropdownMenuContainer = styled.div`
+  position: absolute;
+  top: 100%;
+  right: 0;
+  width: 150%;
+  background: #ffffff;
+  color: #333333;
+  box-shadow: 0 3px 12px 0 rgb(0 0 0/0.15);
+  padding: 2px;
+  box-sizing: border-box;
+  border-radius: 8px;
+  margin-top: 4px;
+  max-height: 300px;
+  z-index: 101;
+
+  @media screen and (max-width: 768px) {
+    top: 110%;
+    width: 220%;
+    margin-top: 2px;
+    border-radius: 4px;
+    overflow-x: hidden;
+  }
+`;
+
+const SearchInputContainer = styled.div`
+  position: relative;
+  width: 100%;
+
+  @media screen and (max-width: 768px) {
+    padding: 2px 4px;
+  }
+`;
+
+const SearchInput = styled.input`
+  width: 100%;
+  padding: 10px;
+  border: none;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  outline: none;
+  font-size: 16px;
+  box-sizing: border-box;
+
+  @media screen and (max-width: 768px) {
+    font-size: 16px;
+    background: transparent;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    border-radius: 0px;
+  }
+`;
+
+const SearchIcon = styled(FaSearch)`
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #a3a3a3;
+  cursor: pointer;
+
+  @media screen and (max-width: 768px) {
+    right: 12px;
+    width: 14px;
+    height: 14px;
+  }
+`;
+
+const ItemContainer = styled.div`
+  width: 100%;
+  max-height: 250px;
+  overflow-y: auto;
+
+  @media screen and (max-width: 768px) {
+    max-height: 100%;
+  }
+`;

--- a/src/components/Article/FilterDrowndown/index.tsx
+++ b/src/components/Article/FilterDrowndown/index.tsx
@@ -1,0 +1,59 @@
+import styled from 'styled-components';
+import { useState } from 'react';
+import DropdownMenu, { DropdownMenuProps } from './DropdownMenu';
+
+interface DropdownItem {
+  type: 'dropdown';
+  id: string;
+  props: DropdownMenuProps;
+}
+
+interface SeparatorItem {
+  type: 'separator';
+  id: string;
+}
+
+export type FilterBarItem = DropdownItem | SeparatorItem;
+
+interface DropdownFilterBarProps {
+  items: FilterBarItem[];
+}
+export default function DropdownFilterBar({ items }: DropdownFilterBarProps) {
+  const [isHover, setIsHover] = useState<boolean>(false);
+
+  return (
+    <FilterDropdownContainer
+      onMouseEnter={() => setIsHover(true)}
+      onMouseLeave={() => setIsHover(false)}
+    >
+      {items.map((item) =>
+        item.type === 'dropdown' ? (
+          <DropdownMenu key={item.id} {...item.props} />
+        ) : (
+          <Separator key={item.id} $isHidden={isHover} />
+        )
+      )}
+    </FilterDropdownContainer>
+  );
+}
+
+const FilterDropdownContainer = styled.div`
+  height: 36px;
+  display: flex;
+  align-items: center;
+  border: 1px solid #a5a5a5;
+  border-radius: 10px;
+  background-color: white;
+  box-sizing: border-box;
+
+  svg {
+    margin-right: 4px;
+  }
+`;
+
+const Separator = styled.div<{ $isHidden?: boolean }>`
+  width: 1px;
+  height: 45%;
+  background-color: ${({ $isHidden }) => ($isHidden ? 'white' : '#c7c7c7')};
+  margin: auto 0px;
+`;

--- a/src/components/Detail/RotationArticleItem.tsx
+++ b/src/components/Detail/RotationArticleItem.tsx
@@ -6,15 +6,15 @@ import useIsMobile from '@/hooks/useIsMobile';
 
 export default function RotationArticleItem({
   item,
-  tickerId,
+  tickerCode,
 }: {
   item: DetailArticleData;
-  tickerId: string;
+  tickerCode: string;
 }) {
   const isMobile = useIsMobile();
   const navigate = useNavigate();
   const handleClick = () => {
-    navigate(`/news?tickerId=${tickerId}`);
+    navigate(`/news?tickerCode=${tickerCode}`);
   };
 
   const getSentimentInfo = () => {

--- a/src/components/Detail/RotationArticleItem.tsx
+++ b/src/components/Detail/RotationArticleItem.tsx
@@ -1,16 +1,20 @@
 import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
 import { Text } from '../common/typography/Text';
 import { DetailArticleData } from '@/types';
 import useIsMobile from '@/hooks/useIsMobile';
 
 export default function RotationArticleItem({
   item,
+  tickerId,
 }: {
   item: DetailArticleData;
+  tickerId: string;
 }) {
   const isMobile = useIsMobile();
+  const navigate = useNavigate();
   const handleClick = () => {
-    return location.pathname === '/news';
+    navigate(`/news?tickerId=${tickerId}`);
   };
 
   const getSentimentInfo = () => {

--- a/src/components/Ticker/TickerItem.tsx
+++ b/src/components/Ticker/TickerItem.tsx
@@ -24,11 +24,23 @@ export default function TickerItem({ item }: { item: PredictionDataResponse }) {
       </TickerInfo>
       <PriceInfo>
         <Text size={isMobile ? 's' : 'm'} weight="bold" variant={getVariant}>
-          {getSignSymbol} {item.predictionStrategy} 추천
+          {getSignSymbol} {item.predictionStrategy} 신호
         </Text>
-        <Text size={isMobile ? 'xxs' : 'xs'} weight="bold" variant={getVariant}>
-          {getSentiment} 기사 {item.articleCount}건
-        </Text>
+        <ArticleChip $variant={getVariant}>
+          <Text
+            size={isMobile ? '12px' : 'xxs'}
+            weight="bold"
+            variant={
+              getVariant === 'red'
+                ? '#ef4444'
+                : getVariant === 'blue'
+                  ? '#3b82f6'
+                  : '#6b7280'
+            }
+          >
+            {getSentiment} 기사 {item.articleCount}건
+          </Text>
+        </ArticleChip>
       </PriceInfo>
     </Wrapper>
   );
@@ -67,5 +79,26 @@ const PriceInfo = styled.div`
   }
   svg {
     margin-right: -3px;
+  }
+`;
+
+const ArticleChip = styled.div<{ $variant: string }>`
+  display: flex;
+  align-items: end;
+  justify-content: flex-end;
+  padding: 6px 10px;
+  border-radius: 18px;
+  background-color: ${(props) =>
+    props.$variant === 'red'
+      ? '#ffecec'
+      : props.$variant === 'blue'
+        ? '#e6f0ff'
+        : '#f0f0f0'};
+  color: ${(props) => props.$variant}15;
+  width: fit-content;
+  margin-left: auto;
+
+  @media screen and (max-width: 768px) {
+    padding: 4px 8px;
   }
 `;

--- a/src/components/common/Layout/MainHeader.tsx
+++ b/src/components/common/Layout/MainHeader.tsx
@@ -4,20 +4,13 @@ import { forwardRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 type HeaderProps = {
-  onMouseEnter: React.MouseEventHandler<HTMLDivElement>;
-  onMouseLeave: React.MouseEventHandler<HTMLDivElement>;
   onClick: () => void;
 };
 export const MainHeader = forwardRef<HTMLDivElement, HeaderProps>(
   (props, ref) => {
     const navigate = useNavigate();
     return (
-      <HeaderContainer
-        ref={ref}
-        onMouseEnter={props.onMouseEnter}
-        onMouseLeave={props.onMouseLeave}
-        onClick={props.onClick}
-      >
+      <HeaderContainer ref={ref} onClick={props.onClick}>
         <LogoWrapper
           src={Logo}
           alt="Articker Logo"

--- a/src/components/common/Layout/MainLayout.tsx
+++ b/src/components/common/Layout/MainLayout.tsx
@@ -1,5 +1,5 @@
 import { Outlet, useLocation } from 'react-router-dom';
-import { Suspense, useEffect, useRef, useState } from 'react';
+import { Suspense, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import { ErrorBoundary } from 'react-error-boundary';
@@ -18,8 +18,6 @@ export default function MainLayout() {
   const isTouch = useIsTouchDevice();
   const location = useLocation();
   const [menuOpen, setMenuOpen] = useState(true);
-  const [isHover, setIsHover] = useState(true);
-  const [forceClose, setForceClose] = useState(false);
   const subHeaderRef = useRef<HTMLDivElement>(null);
   const headerRef = useRef<HTMLDivElement>(null);
   const scrollDirection = useScrollDirection();
@@ -35,64 +33,19 @@ export default function MainLayout() {
   };
 
   useScrollToTop();
-  const handleMouseEnter = () => {
-    if (!isTouch) setIsHover(true);
-  };
-  const handleMouseLeave = () => {
-    if (!isTouch) setIsHover(false);
-  };
   const handleHeaderClick = () => {
     if (isTouch) {
-      setForceClose(false);
       if (!menuOpen) setMenuOpen(true);
     }
   };
-  const showHeader = isTouch
-    ? !forceClose && (menuOpen || scrollDirection === 'up')
-    : isHover || scrollDirection === 'up';
-
-  useEffect(() => {
-    if (scrollDirection === 'down') setForceClose(false);
-  }, [scrollDirection]);
+  const showHeader = scrollDirection === 'up' || scrollDirection === null;
 
   // 바깥 클릭 시 메뉴 닫기
-  useEffect(() => {
-    if (!showHeader) return;
-    const handleClick = (event: MouseEvent | TouchEvent) => {
-      if (!isTouch) return;
-      if (
-        (subHeaderRef.current &&
-          subHeaderRef.current.contains(event.target as Node)) ||
-        (headerRef.current && headerRef.current.contains(event.target as Node))
-      ) {
-        return;
-      }
-      setMenuOpen(false);
-      setForceClose(true);
-    };
-
-    document.addEventListener('mousedown', handleClick);
-    document.addEventListener('touchstart', handleClick);
-    return () => {
-      document.removeEventListener('mousedown', handleClick);
-      document.removeEventListener('touchstart', handleClick);
-    };
-  }, [showHeader, isTouch]);
 
   return (
     <Wrapper>
-      <MainHeader
-        ref={headerRef}
-        onClick={handleHeaderClick}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-      />
-      <SubHeader
-        visible={showHeader}
-        ref={subHeaderRef}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
-      />
+      <MainHeader ref={headerRef} onClick={handleHeaderClick} />
+      <SubHeader visible={showHeader} ref={subHeaderRef} />
       <InnerWrapper>
         <QueryErrorResetBoundary>
           {({ reset }) => (

--- a/src/components/common/Layout/SubHeader.tsx
+++ b/src/components/common/Layout/SubHeader.tsx
@@ -5,12 +5,10 @@ import { HEADER_HEIGHT } from './MainHeader';
 
 type SubHeaderProps = {
   visible: boolean;
-  onMouseEnter: React.MouseEventHandler<HTMLDivElement>;
-  onMouseLeave: React.MouseEventHandler<HTMLDivElement>;
 };
 
 export const SubHeader = forwardRef<HTMLDivElement, SubHeaderProps>(
-  ({ visible, onMouseEnter, onMouseLeave }, ref) => {
+  ({ visible }, ref) => {
     const location = useLocation();
 
     const isActive = (path: string) => {
@@ -21,12 +19,7 @@ export const SubHeader = forwardRef<HTMLDivElement, SubHeaderProps>(
       return location.pathname.startsWith(path);
     };
     return (
-      <HeaderContainer
-        $show={visible}
-        ref={ref}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-      >
+      <HeaderContainer $show={visible} ref={ref}>
         <Item aria-label="header-home" to="/" $isActive={isActive('/')}>
           홈
         </Item>

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+
+export default function useClickOutside(
+  refs: React.RefObject<HTMLElement>[],
+  callback: () => void
+) {
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      const isInside = refs.some((ref) =>
+        ref.current?.contains(event.target as Node)
+      );
+      if (!isInside) {
+        callback();
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [refs, callback]);
+}

--- a/src/mocks/newsHandler.ts
+++ b/src/mocks/newsHandler.ts
@@ -403,7 +403,9 @@ export const newsHandlers = [
     return HttpResponse.json({
       code: '200 OK',
       message: '아티클 티커 필터링 - 티커 목록을 성공적으로 조회하였습니다.',
-      content: mockTickerTypes[0].content.tickerList,
+      content: {
+        tickerList: mockTickerTypes[0].content.tickerList,
+      },
     });
   }),
 ];

--- a/src/mocks/newsHandler.ts
+++ b/src/mocks/newsHandler.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from 'msw';
 import { BASE_URL } from '@/api/instance';
 import { getInfiniteArticleListPath } from '@/api/hooks/useGetInfiniteArticleList';
+import { getFilterTickerListPath } from '@/api/hooks/useGetFilterTickerList';
 
 const mockNewsList = [
   {
@@ -211,6 +212,171 @@ const mockNewsList = [
   },
 ];
 
+const mockTickerTypes = [
+  {
+    code: '200 OK',
+    content: {
+      tickerList: [
+        {
+          tickerId: '2b86190f-ac3f-4154-9532-dfecb99017f2',
+          shortCompanyName: 'AMD',
+          tickerCode: 'AMD',
+        },
+        {
+          tickerId: '338ce24f-af29-47f2-9e65-495609181621',
+          shortCompanyName: 'Apple',
+          tickerCode: 'AAPL',
+        },
+        {
+          tickerId: '0cd501a6-b759-4b34-ad65-981d7d587bc7',
+          shortCompanyName: 'Microsoft',
+          tickerCode: 'MSFT',
+        },
+        {
+          tickerId: '1378939e-14dc-4067-a4ff-d5ffc22d1ece',
+          shortCompanyName: 'Amazon',
+          tickerCode: 'AMZN',
+        },
+        {
+          tickerId: '96ead7db-621b-4bd6-874f-ce490c420d20',
+          shortCompanyName: 'Tesla',
+          tickerCode: 'TSLA',
+        },
+        {
+          tickerId: 'bacdf2ae-6243-41b1-a8ec-41f4262cd832',
+          shortCompanyName: 'Walmart',
+          tickerCode: 'WMT',
+        },
+        {
+          tickerId: 'b687c355-d177-474a-aa69-1e8d93dd791f',
+          shortCompanyName: 'JPMorgan Chase',
+          tickerCode: 'JPM',
+        },
+        {
+          tickerId: '192ab252-9d3e-4761-aa44-3e7c1f8e42ee',
+          shortCompanyName: 'Johnson & Johnson',
+          tickerCode: 'JNJ',
+        },
+        {
+          tickerId: '168a0492-3189-487a-8f0a-77b71d6b8a0a',
+          shortCompanyName: 'Visa',
+          tickerCode: 'V',
+        },
+        {
+          tickerId: '57e07ebc-d3c9-46da-bd29-22e30a98be1d',
+          shortCompanyName: 'Exxon Mobil',
+          tickerCode: 'XOM',
+        },
+        {
+          tickerId: '19617ed1-34f0-4a81-baca-277c2bac88c7',
+          shortCompanyName: 'Coca-Cola',
+          tickerCode: 'KO',
+        },
+        {
+          tickerId: 'e65bd0db-c2c2-4168-8f42-2d9b50388337',
+          shortCompanyName: 'NVIDIA',
+          tickerCode: 'NVDA',
+        },
+        {
+          tickerId: '8536c00b-be96-4538-8723-878ec00695df',
+          shortCompanyName: 'Netflix',
+          tickerCode: 'NFLX',
+        },
+        {
+          tickerId: 'c22fd3b6-f11d-4f83-a3e6-477f91b9b4f4',
+          shortCompanyName: 'Adobe',
+          tickerCode: 'ADBE',
+        },
+        {
+          tickerId: '31985023-9e72-4a72-98c9-8066a5fb3e62',
+          shortCompanyName: 'Salesforce',
+          tickerCode: 'CRM',
+        },
+        {
+          tickerId: '1fa28e50-f396-42fe-9fa7-6092145e57ff',
+          shortCompanyName: 'Qualcomm',
+          tickerCode: 'QCOM',
+        },
+        {
+          tickerId: 'b9a88e4b-45db-44c1-8f90-f2ec37ced1dd',
+          shortCompanyName: 'Intel',
+          tickerCode: 'INTC',
+        },
+        {
+          tickerId: 'e41d6afd-2cd7-4b97-9169-cab48e98bce0',
+          shortCompanyName: 'Oracle',
+          tickerCode: 'ORCL',
+        },
+        {
+          tickerId: '57b62038-4a9f-467a-96f3-4cbd1e619b4b',
+          shortCompanyName: 'Bank of America',
+          tickerCode: 'BAC',
+        },
+        {
+          tickerId: 'eeabb4ed-daab-4de4-a524-53b52c2c6cca',
+          shortCompanyName: 'Goldman Sachs',
+          tickerCode: 'GS',
+        },
+        {
+          tickerId: 'fefe2e62-ad94-4b94-935a-912e6fc3581c',
+          shortCompanyName: 'P&G',
+          tickerCode: 'PG',
+        },
+        {
+          tickerId: '7f99d78b-3070-4c42-80f3-5710ffe4ca15',
+          shortCompanyName: 'Home Depot',
+          tickerCode: 'HD',
+        },
+        {
+          tickerId: '1a5ef443-f436-49d4-b816-807bb754190d',
+          shortCompanyName: "McDonald's",
+          tickerCode: 'MCD',
+        },
+        {
+          tickerId: 'a02ce5ec-d634-4485-8c4f-d9104e02c651',
+          shortCompanyName: 'Eli Lilly',
+          tickerCode: 'LLY',
+        },
+        {
+          tickerId: 'e4603a9e-1745-4530-85e1-8e2d425e0f41',
+          shortCompanyName: 'UnitedHealth',
+          tickerCode: 'UNH',
+        },
+        {
+          tickerId: 'f3009712-f9a5-4ac2-a67e-2476d658f0b5',
+          shortCompanyName: 'Pfizer',
+          tickerCode: 'PFE',
+        },
+        {
+          tickerId: '463348b5-e166-4cc4-bfb9-f13b405ca1ec',
+          shortCompanyName: 'Broadcom',
+          tickerCode: 'AVGO',
+        },
+        {
+          tickerId: 'abec59d2-7c6e-414f-9994-c4c30331ffc6',
+          shortCompanyName: 'Costco',
+          tickerCode: 'COST',
+        },
+        {
+          tickerId: '4bf3ab58-23e8-4d63-a151-530f530d3e51',
+          shortCompanyName: 'Disney',
+          tickerCode: 'DIS',
+        },
+        {
+          tickerId: '75124d2c-e7d3-4ee6-bcae-3a0786294345',
+          shortCompanyName: 'Google',
+          tickerCode: 'GOOGL',
+        },
+        {
+          tickerId: '67fdafec-a741-425e-bc8e-d86249b4642b',
+          shortCompanyName: 'Meta',
+          tickerCode: 'META',
+        },
+      ],
+    },
+  },
+];
+
 export const newsHandlers = [
   http.get(`${BASE_URL}${getInfiniteArticleListPath()}`, ({ request }) => {
     const url = new URL(request.url);
@@ -231,6 +397,13 @@ export const newsHandlers = [
         pageNumber: page,
         hasNext: page < totalPages - 1,
       },
+    });
+  }),
+  http.get(`${BASE_URL}${getFilterTickerListPath()}`, () => {
+    return HttpResponse.json({
+      code: '200 OK',
+      message: '아티클 티커 필터링 - 티커 목록을 성공적으로 조회하였습니다.',
+      content: mockTickerTypes[0].content.tickerList,
     });
   }),
 ];

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -276,6 +276,7 @@ export default function DetailPage() {
             <RotationArticleItem
               key={currentNewsIndex}
               item={tickerData.detailData.article[currentNewsIndex]}
+              tickerId={tickerData.tickerId}
             />
           </>
         )}

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -11,7 +11,7 @@ import { useGetTickerDetail } from '@/api/hooks/useGetTickerDetail';
 import { useGetRealGraph, RealGraphPeriod } from '@/api/hooks/useGetRealGraph';
 import { useGetRealTimePrice } from '@/api/hooks/useGetRealTimePrice';
 import Loading from '@/components/common/Layout/Loading';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { Paragraph } from '@/components/common/typography/Paragraph';
 import RotationArticleItem from '@/components/Detail/RotationArticleItem';
@@ -24,6 +24,7 @@ export default function DetailPage() {
   const [showTooltip, setShowTooltip] = useState(false);
   const [showRefreshTooltip, setShowRefreshTooltip] = useState(false);
   const [currentNewsIndex, setCurrentNewsIndex] = useState(0);
+  const scrollPositionRef = useRef(0);
   const queryClient = useQueryClient();
   const isMobile = useIsMobile();
 
@@ -80,6 +81,27 @@ export default function DetailPage() {
     setTimeout(() => {
       setShowRefreshTooltip(false);
     }, 3000);
+  };
+
+  const handlePeriodChange = (newPeriod: RealGraphPeriod) => {
+    scrollPositionRef.current = window.scrollY;
+    setPeriod(newPeriod);
+    setIsLiveMode(false);
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        window.scrollTo(0, scrollPositionRef.current);
+      });
+    });
+  };
+
+  const handleLiveMode = () => {
+    scrollPositionRef.current = window.scrollY;
+    setIsLiveMode(true);
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        window.scrollTo(0, scrollPositionRef.current);
+      });
+    });
   };
 
   const formatDate = (priceDate: string) => {
@@ -233,15 +255,12 @@ export default function DetailPage() {
             <PeriodButton
               key={p}
               $active={period === p && !isLiveMode}
-              onClick={() => {
-                setPeriod(p);
-                setIsLiveMode(false);
-              }}
+              onClick={() => handlePeriodChange(p)}
             >
               {p}
             </PeriodButton>
           ))}
-          <LiveButton $active={isLiveMode} onClick={() => setIsLiveMode(true)}>
+          <LiveButton $active={isLiveMode} onClick={handleLiveMode}>
             live
             <LiveDot />
           </LiveButton>

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -295,7 +295,7 @@ export default function DetailPage() {
             <RotationArticleItem
               key={currentNewsIndex}
               item={tickerData.detailData.article[currentNewsIndex]}
-              tickerId={tickerData.tickerId}
+              tickerCode={tickerData.tickerCode}
             />
           </>
         )}

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -4,13 +4,13 @@ import { Paragraph } from '@/components/common/typography/Paragraph';
 import TickerList from '@/components/Ticker/TickerList';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
-import { useGetPopularTickers } from '@/api/hooks/useGetInfiniteTickerList';
+import { useGetInfiniteTickerList } from '@/api/hooks/useGetInfiniteTickerList';
 import MarketStatusBanner from '@/components/common/Banner/MarketStatusBanner';
 import useIsMobile from '@/hooks/useIsMobile';
 
 export default function MainPage() {
   const navigate = useNavigate();
-  const { data: popularData } = useGetPopularTickers();
+  const { data: popularData } = useGetInfiniteTickerList({ sort: 'popular' });
   const isMobile = useIsMobile();
   return (
     <Wrapper>

--- a/src/pages/NewsBoard/index.tsx
+++ b/src/pages/NewsBoard/index.tsx
@@ -19,10 +19,16 @@ export default function NewsBoardPage() {
     return (searchParams.get('filter') as NewsFilter) || 'all';
   }, [location.search]);
 
+  const getTickerId = useCallback((): string | undefined => {
+    const searchParams = new URLSearchParams(location.search);
+    return searchParams.get('tickerId') || undefined;
+  }, [location.search]);
+
   const [filter, setFilter] = useState<NewsFilter>(getInitialFilter());
   const [sort] = useState<NewsSort>('recent');
   const [isInitialLoad, setIsInitialLoad] = useState(true);
   const { ref, inView } = useInView();
+  const tickerId = getTickerId();
 
   const {
     data: articleList,
@@ -31,7 +37,7 @@ export default function NewsBoardPage() {
     hasNextPage: hasNext,
     isFetchingNextPage,
     fetchNextPage,
-  } = useGetInfiniteArticleList({ filter, sort });
+  } = useGetInfiniteArticleList({ filter, sort, tickerId });
 
   const handleFilterChange = (newFilter: NewsFilter) => {
     const searchParams = new URLSearchParams(location.search);

--- a/src/pages/NewsBoard/index.tsx
+++ b/src/pages/NewsBoard/index.tsx
@@ -80,7 +80,7 @@ export default function NewsBoardPage() {
         id: 'ticker-filter',
         props: {
           options:
-            filterTickerData?.content?.map((ticker) => ({
+            filterTickerData?.content?.tickerList.map((ticker) => ({
               label: ticker.shortCompanyName,
               id: ticker.tickerCode,
             })) || [],
@@ -164,7 +164,7 @@ export default function NewsBoardPage() {
       <ChipContainer>
         <Chip
           selectedTickers={
-            filterTickerData?.content?.filter((ticker) =>
+            filterTickerData?.content?.tickerList.filter((ticker) =>
               currentTickerCodes.includes(ticker.tickerCode)
             ) || []
           }

--- a/src/pages/NewsBoard/index.tsx
+++ b/src/pages/NewsBoard/index.tsx
@@ -83,7 +83,7 @@ export default function NewsBoardPage() {
         >
           전체
         </FilterTab>
-        {/* <FilterTab
+        <FilterTab
           $active={filter === 'positive'}
           onClick={() => handleFilterChange('positive')}
         >
@@ -94,7 +94,7 @@ export default function NewsBoardPage() {
           onClick={() => handleFilterChange('negative')}
         >
           부정
-        </FilterTab> */}
+        </FilterTab>
       </FilterContainer>
 
       <ArticleList items={allArticles} />

--- a/src/pages/NewsBoard/index.tsx
+++ b/src/pages/NewsBoard/index.tsx
@@ -19,16 +19,16 @@ export default function NewsBoardPage() {
     return (searchParams.get('filter') as NewsFilter) || 'all';
   }, [location.search]);
 
-  const getTickerId = useCallback((): string | undefined => {
+  const getTickerCodes = useCallback((): string[] => {
     const searchParams = new URLSearchParams(location.search);
-    return searchParams.get('tickerId') || undefined;
+    return searchParams.getAll('tickerCode');
   }, [location.search]);
 
   const [filter, setFilter] = useState<NewsFilter>(getInitialFilter());
   const [sort] = useState<NewsSort>('recent');
   const [isInitialLoad, setIsInitialLoad] = useState(true);
   const { ref, inView } = useInView();
-  const tickerId = getTickerId();
+  const currentTickerCodes = getTickerCodes();
 
   const {
     data: articleList,
@@ -37,7 +37,11 @@ export default function NewsBoardPage() {
     hasNextPage: hasNext,
     isFetchingNextPage,
     fetchNextPage,
-  } = useGetInfiniteArticleList({ filter, sort, tickerId });
+  } = useGetInfiniteArticleList({
+    filter,
+    sort,
+    tickerCode: currentTickerCodes.length > 0 ? currentTickerCodes : undefined,
+  });
 
   const handleFilterChange = (newFilter: NewsFilter) => {
     const searchParams = new URLSearchParams(location.search);
@@ -60,7 +64,7 @@ export default function NewsBoardPage() {
 
   useEffect(() => {
     setFilter(getInitialFilter());
-  }, [getInitialFilter]);
+  }, [getInitialFilter, location.search]);
 
   if (isLoading) {
     return <Loading />;

--- a/src/pages/Ticker/index.tsx
+++ b/src/pages/Ticker/index.tsx
@@ -1,13 +1,25 @@
 import TickerList from '@/components/Ticker/TickerList';
 import styled from 'styled-components';
-import { useGetPopularTickers } from '@/api/hooks/useGetInfiniteTickerList';
-import { useEffect, useState } from 'react';
+import { useGetInfiniteTickerList } from '@/api/hooks/useGetInfiniteTickerList';
+import { useCallback, useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useInView } from 'react-intersection-observer';
 import Loading from '@/components/common/Layout/Loading';
 import SearchBar from '@/components/common/SearchBar';
 
+type TickerFilter = 'popular' | 'upward' | 'downward';
+
 export default function TickerPage() {
   const [isInitialLoad, setIsInitialLoad] = useState(true);
+  const location = useLocation();
+
+  const getInitialFilter = useCallback((): TickerFilter => {
+    const searchParams = new URLSearchParams(location.search);
+    return (searchParams.get('filter') as TickerFilter) || 'popular';
+  }, [location.search]);
+
+  const [filter, setFilter] = useState<TickerFilter>(getInitialFilter());
+  const navigate = useNavigate();
   const { ref, inView } = useInView();
   const {
     data: tickerData,
@@ -16,7 +28,14 @@ export default function TickerPage() {
     hasNextPage: hasNext,
     isFetchingNextPage,
     fetchNextPage,
-  } = useGetPopularTickers();
+  } = useGetInfiniteTickerList({ sort: filter });
+
+  const handleFilterChange = (newFilter: TickerFilter) => {
+    const searchParams = new URLSearchParams(location.search);
+    searchParams.set('filter', newFilter);
+    navigate(`${location.pathname}?${searchParams.toString()}`);
+    setFilter(newFilter);
+  };
 
   useEffect(() => {
     if (tickerData?.pages && tickerData.pages.length > 0) {
@@ -29,6 +48,10 @@ export default function TickerPage() {
       fetchNextPage();
     }
   }, [inView, hasNext, isFetchingNextPage, fetchNextPage, isInitialLoad]);
+
+  useEffect(() => {
+    setFilter(getInitialFilter());
+  }, [getInitialFilter]);
 
   if (isLoading) {
     return <Loading />;
@@ -48,6 +71,26 @@ export default function TickerPage() {
   return (
     <Wrapper>
       <SearchBar />
+      <FilterContainer>
+        <FilterTab
+          $active={filter === 'popular'}
+          onClick={() => handleFilterChange('popular')}
+        >
+          인기순
+        </FilterTab>
+        <FilterTab
+          $active={filter === 'upward'}
+          onClick={() => handleFilterChange('upward')}
+        >
+          점수▲
+        </FilterTab>
+        <FilterTab
+          $active={filter === 'downward'}
+          onClick={() => handleFilterChange('downward')}
+        >
+          점수▼
+        </FilterTab>
+      </FilterContainer>
       <TickerList items={allTickers} />
       <div ref={ref} style={{ height: '50px' }} />
       {isFetchingNextPage && <Loading />}
@@ -65,6 +108,33 @@ const Wrapper = styled.div`
     width: 84%;
     gap: 30px;
     padding: 12px 0;
+  }
+`;
+
+const FilterContainer = styled.div`
+  display: flex;
+  gap: 20px;
+  margin-top: -16px;
+
+  @media screen and (max-width: 768px) {
+    margin-top: -32px;
+    margin-bottom: -10px;
+  }
+`;
+
+const FilterTab = styled.button<{ $active: boolean }>`
+  padding: 12px 18px;
+  font-size: 16px;
+  font-weight: bold;
+  border: none;
+  border-bottom: 3px solid ${(props) => (props.$active ? '#2d70d3' : '#8c8c8c')};
+  background: none;
+  cursor: pointer;
+  color: ${(props) => (props.$active ? '#2d70d3' : '#8c8c8c')};
+
+  @media screen and (max-width: 768px) {
+    padding: 10px 20px;
+    font-size: 14px;
   }
 `;
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -114,3 +114,9 @@ export type RealTimePriceData = {
   priceDataList: TickerRealTimeGraphResponse[];
   maxLen: number;
 };
+
+export type ArticleTickerFilteringResponse = {
+  tickerId: string;
+  shortCompanyName: string;
+  tickerCode: string;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -115,6 +115,10 @@ export type RealTimePriceData = {
   maxLen: number;
 };
 
+export type ArticleTickerListData = {
+  tickerList: ArticleTickerFilteringResponse[];
+};
+
 export type ArticleTickerFilteringResponse = {
   tickerId: string;
   shortCompanyName: string;


### PR DESCRIPTION
- [x] 종목 페이지에 정렬 옵션(높은 점수순, 낮은 점수순) 추가
- [x] 뉴스보드 페이지에 정렬 옵션(긍정, 부정) 추가
- [x] rotationArticle 누르면 필터링된 뉴스보드로 이동하도록 수정
- [x] 헤더 스크롤 동작 개선(스크롤 방향에 따라서만 영향받도록)
- [x] detail 페이지에서 그래프 주기 변경 시 스크롤 위치 복원하는 기능 추가
- [x] 아티클 필터링 기준을 tickerCode로 변경 및 필터링 다중 선택 구현
- [x] 아티클 종목 필터링 드롭다운 메뉴 및 칩 컴포넌트 추가
- [x] tickerItem UI 변경 (predictionStrategy 표현 및 관련 기사)
- [x] 잘못된 응답 타입 수정
- [x] 아티클 필터링 파라미터 변경 및 캐싱 최적화
