### PR TITLE
[Articker - 15] 뉴스 요약 순환 애니메이션 및 로직 개선(positiveIndex/negativeIndex 분리)

### DIFF
--- a/src/components/Main/ArticleSummary/index.tsx
+++ b/src/components/Main/ArticleSummary/index.tsx
@@ -14,18 +14,25 @@ export default function ArticleSummary() {
 
   useEffect(() => {
     const positiveReasoning = data?.content.positiveReasoning;
-    const negativeReasoning = data?.content.negativeReasoning;
-
-    if (!positiveReasoning || !negativeReasoning) return;
-    if (positiveReasoning.length < 2 || negativeReasoning.length < 2) return;
+    if (!positiveReasoning || positiveReasoning.length < 2) return;
 
     const interval = setInterval(() => {
       setPositiveIndex((prev) => (prev + 1) % positiveReasoning.length);
+    }, 10000);
+
+    return () => clearInterval(interval);
+  }, [data?.content.positiveReasoning]);
+
+  useEffect(() => {
+    const negativeReasoning = data?.content.negativeReasoning;
+    if (!negativeReasoning || negativeReasoning.length < 2) return;
+
+    const interval = setInterval(() => {
       setNegativeIndex((prev) => (prev + 1) % negativeReasoning.length);
     }, 10000);
 
     return () => clearInterval(interval);
-  }, [data?.content.positiveReasoning, data?.content.negativeReasoning]);
+  }, [data?.content.negativeReasoning]);
 
   if (isLoading || isError || !data || !data.content) {
     return null;


### PR DESCRIPTION
- [x] codeRabbit 코드리뷰 반영

> useEffect에서 접근성과 로직 개선 필요
useEffect 구현은 cleanup 함수가 올바르지만 두 가지 주요 개선사항이 필요합니다:
로직 이슈: 20줄의 OR 조건은 positiveReasoning 또는 negativeReasoning 중 하나라도 항목이 2개 미만이면 양쪽 모두 순환하지 않게 합니다. 예를 들어 positiveReasoning에 3개, negativeReasoning에 1개만 있다면 positiveReasoning도 순환하지 않습니다. 각 배열을 독립적으로 순환하는 것이 더 나은 UX입니다.