### PR TITLE
[Articker - 15] ticker 키워드가 둘 다 없을 때 처리하는 NoItem 컴포넌트 추가

### DIFF
--- a/src/components/Main/ArticleSummary/index.tsx
+++ b/src/components/Main/ArticleSummary/index.tsx
@@ -14,18 +14,25 @@ export default function ArticleSummary() {
 
   useEffect(() => {
     const positiveReasoning = data?.content.positiveReasoning;
-    const negativeReasoning = data?.content.negativeReasoning;
-
-    if (!positiveReasoning || !negativeReasoning) return;
-    if (positiveReasoning.length < 2 || negativeReasoning.length < 2) return;
+    if (!positiveReasoning || positiveReasoning.length < 2) return;
 
     const interval = setInterval(() => {
       setPositiveIndex((prev) => (prev + 1) % positiveReasoning.length);
+    }, 10000);
+
+    return () => clearInterval(interval);
+  }, [data?.content.positiveReasoning]);
+
+  useEffect(() => {
+    const negativeReasoning = data?.content.negativeReasoning;
+    if (!negativeReasoning || negativeReasoning.length < 2) return;
+
+    const interval = setInterval(() => {
       setNegativeIndex((prev) => (prev + 1) % negativeReasoning.length);
     }, 10000);
 
     return () => clearInterval(interval);
-  }, [data?.content.positiveReasoning, data?.content.negativeReasoning]);
+  }, [data?.content.negativeReasoning]);
 
   if (isLoading || isError || !data || !data.content) {
     return null;

--- a/src/components/Ticker/ABTest/KeywordView.tsx
+++ b/src/components/Ticker/ABTest/KeywordView.tsx
@@ -75,7 +75,7 @@ export default function KeywordView({
           </Text>
         </SignalChip>
       </ChipContainer>
-      {hasKeywords && (
+      {hasKeywords ? (
         <KeywordContent>
           <KeywordList>
             {visibleKeywords.map((keyword, index) => (
@@ -102,6 +102,12 @@ export default function KeywordView({
             )}
           </KeywordList>
         </KeywordContent>
+      ) : (
+        <NoKeywordMessage>
+          <Text size={isMobile ? '12px' : 'xxs'} weight="normal" variant="gray">
+            분석된 키워드가 없습니다
+          </Text>
+        </NoKeywordMessage>
       )}
     </KeywordSection>
   );
@@ -205,4 +211,10 @@ const KeywordChip = styled.div<{ $variant: string }>`
     margin-top: 0;
     height: 18px;
   }
+`;
+
+const NoKeywordMessage = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 4px 6px;
 `;

--- a/src/components/Ticker/ABTest/KeywordView.tsx
+++ b/src/components/Ticker/ABTest/KeywordView.tsx
@@ -104,7 +104,7 @@ export default function KeywordView({
         </KeywordContent>
       ) : (
         <NoKeywordMessage>
-          <Text size={isMobile ? '12px' : 'xxs'} weight="normal" variant="gray">
+          <Text size={isMobile ? '12px' : 'xxs'} weight="normal" variant="grey">
             분석된 키워드가 없습니다
           </Text>
         </NoKeywordMessage>


### PR DESCRIPTION
- [x] 뉴스 요약 순환 애니메이션 및 로직 개선(positiveIndex/negativeIndex 분리
- [x] positiveKeywords와 negativeKeywords가 둘 다 없을 때 처리하는 NoItem 컴포넌트 추가