### PR TITLE
[Articker - 20] 로그아웃 기능 및 NotFound 페이지 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import NewsBoardPage from './pages/NewsBoard';
 import ArticleDetailPage from './pages/ArticleDetail';
 import CallbackPage from './pages/Callback';
 import JoinPage from './pages/Join';
+import NotFoundPage from './pages/NotFound';
 import GlobalStyle from './global';
 
 function App() {
@@ -32,6 +33,7 @@ function App() {
           <Route path="/ticker/:id" element={<DetailPage />} />
           <Route path="/news" element={<NewsBoardPage />} />
           <Route path="/news/:id" element={<ArticleDetailPage />} />
+          <Route path="*" element={<NotFoundPage />} />
           <Route
             path="/join"
             element={

--- a/src/api/hooks/usePostLogout.ts
+++ b/src/api/hooks/usePostLogout.ts
@@ -1,0 +1,24 @@
+import { useMutation } from '@tanstack/react-query';
+import { fetchInstance } from '../instance';
+
+import { ApiEmptyResponse, LogoutRequest } from '@/types';
+
+export const postLogoutPath = () => `/api/v1/logout`;
+
+const postLogout = async ({ deviceType }: LogoutRequest) => {
+  const response = await fetchInstance.post<ApiEmptyResponse>(
+    postLogoutPath(),
+    {
+      deviceType,
+      // refreshToken는 앱 기능 시작할 때 추가
+    },
+    { withCredentials: true }
+  );
+  return response.data;
+};
+
+export const usePostLogout = () => {
+  return useMutation({
+    mutationFn: ({ deviceType }: LogoutRequest) => postLogout({ deviceType }),
+  });
+};

--- a/src/api/hooks/usePostReissueToken.ts
+++ b/src/api/hooks/usePostReissueToken.ts
@@ -1,15 +1,16 @@
 import { useMutation } from '@tanstack/react-query';
 import { fetchInstance } from '../instance';
 
-import { ApiResponse, TokenResponse } from '@/types';
+import { ApiResponse, ReIssueRequest, TokenResponse } from '@/types';
 
 export const postReissueTokenPath = () => `/api/v1/reIssue`;
 
-const postReissueToken = async (deviceType: string) => {
+const postReissueToken = async ({ deviceType }: ReIssueRequest) => {
   const response = await fetchInstance.post<ApiResponse<TokenResponse>>(
     postReissueTokenPath(),
     {
       deviceType,
+      // refreshToken는 앱 기능 시작할 때 추가
     },
     { withCredentials: true }
   );
@@ -18,6 +19,7 @@ const postReissueToken = async (deviceType: string) => {
 
 export const usePostReissueToken = () => {
   return useMutation({
-    mutationFn: (deviceType: string) => postReissueToken(deviceType),
+    mutationFn: ({ deviceType }: ReIssueRequest) =>
+      postReissueToken({ deviceType }),
   });
 };

--- a/src/components/common/Layout/MainHeader.tsx
+++ b/src/components/common/Layout/MainHeader.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import Logo from '@/assets/images/Articker.png';
 import { forwardRef } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
+import useAuth from '@/hooks/useAuth';
 import LoginModal from '@/components/common/Modal/LoginModal';
 
 type HeaderProps = {
@@ -11,6 +12,7 @@ export const MainHeader = forwardRef<HTMLDivElement, HeaderProps>(
   (props, ref) => {
     const navigate = useNavigate();
     const location = useLocation();
+    const { isAuthenticated, handleLogout } = useAuth();
 
     return (
       <HeaderContainer ref={ref} onClick={props.onClick}>
@@ -30,11 +32,15 @@ export const MainHeader = forwardRef<HTMLDivElement, HeaderProps>(
           >
             피드백 남기기
           </NavButton>
-          <LoginModal currentPath={location.pathname}>
-            {(openModal) => (
-              <LoginButton onClick={openModal}>로그인</LoginButton>
-            )}
-          </LoginModal>
+          {isAuthenticated ? (
+            <AuthButton onClick={handleLogout}>로그아웃</AuthButton>
+          ) : (
+            <LoginModal currentPath={location.pathname}>
+              {(openModal) => (
+                <AuthButton onClick={openModal}>로그인</AuthButton>
+              )}
+            </LoginModal>
+          )}
         </ButtonContainer>
       </HeaderContainer>
     );
@@ -92,7 +98,7 @@ const NavButton = styled.button`
   }
 `;
 
-const LoginButton = styled.button`
+const AuthButton = styled.button`
   border: none;
   border-radius: 8px;
   padding: 8px 14px;

--- a/src/pages/NotFound/index.tsx
+++ b/src/pages/NotFound/index.tsx
@@ -1,0 +1,71 @@
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import useIsMobile from '@/hooks/useIsMobile';
+import Button from '@/components/common/Button';
+import { Paragraph } from '@/components/common/typography/Paragraph';
+
+export default function NotFound() {
+  const isMobile = useIsMobile();
+  const navigate = useNavigate();
+  const handleHome = () => {
+    navigate('/');
+  };
+  return (
+    <Wrapper>
+      <TextWrapper>
+        <Paragraph size={isMobile ? 'l' : 'xl'} weight="bold">
+          페이지를 찾을 수 없어요 🥲
+        </Paragraph>
+        <Paragraph size={isMobile ? 's' : 'm'} weight="normal">
+          요청한 페이지가 존재하지 않거나 삭제되었어요.
+        </Paragraph>
+      </TextWrapper>
+      <StyledButton
+        aria-label="NotFound 홈으로"
+        variant="blackOutline"
+        onClick={handleHome}
+      >
+        홈으로 이동하기
+      </StyledButton>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  padding-bottom: 40px;
+  gap: 60px;
+
+  @media screen and (max-width: 768px) {
+    gap: 40px;
+    padding-bottom: 20px;
+  }
+`;
+const TextWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 40px;
+  gap: 20px;
+  white-space: pre-line;
+  line-height: 26px;
+
+  @media screen and (max-width: 768px) {
+    width: 80%;
+    margin-top: 30px;
+  }
+`;
+
+const StyledButton = styled(Button)`
+  width: 30%;
+  @media screen and (max-width: 768px) {
+    width: fit-content;
+    padding: 20px;
+  }
+`;

--- a/src/pages/NotFound/index.tsx
+++ b/src/pages/NotFound/index.tsx
@@ -20,11 +20,7 @@ export default function NotFound() {
           요청한 페이지가 존재하지 않거나 삭제되었어요.
         </Paragraph>
       </TextWrapper>
-      <StyledButton
-        aria-label="NotFound 홈으로"
-        variant="blackOutline"
-        onClick={handleHome}
-      >
+      <StyledButton variant="blackOutline" onClick={handleHome}>
         홈으로 이동하기
       </StyledButton>
     </Wrapper>

--- a/src/provider/Auth/index.tsx
+++ b/src/provider/Auth/index.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { usePostReissueToken } from '@/api/hooks/usePostReissueToken';
+import { usePostLogout } from '@/api/hooks/usePostLogout';
 import { AuthContext } from './AuthContext';
 
 interface AuthProviderProps {
   children: React.ReactNode;
 }
 
-const ACCESS_TOKEN_REFRESH_INTERVAL = 1 * 30 * 1000; // 만료 시간 1시간
+const ACCESS_TOKEN_REFRESH_INTERVAL = 60 * 60 * 1000; // 만료 시간 1시간
 const TOKEN_TIMESTAMP_KEY = 'lastTokenTime';
 
 export default function AuthProvider({ children }: AuthProviderProps) {
@@ -15,13 +16,19 @@ export default function AuthProvider({ children }: AuthProviderProps) {
   );
   const [isInitialized, setIsInitialized] = useState<boolean>(false);
   const { mutateAsync: refreshToken } = usePostReissueToken();
+  const { mutateAsync: logout } = usePostLogout();
 
-  const handleLogout = useCallback(() => {
+  const handleLogout = useCallback(async () => {
+    try {
+      await logout({ deviceType: 'web' });
+    } catch (error) {
+      console.error('Logout failed:', error);
+    }
     setIsAuthenticated(false);
     localStorage.removeItem('isAuthenticated');
     localStorage.removeItem(TOKEN_TIMESTAMP_KEY);
     window.location.href = '/';
-  }, []);
+  }, [logout]);
 
   const refreshTokenRegularly = useCallback(async () => {
     try {

--- a/src/provider/Auth/index.tsx
+++ b/src/provider/Auth/index.tsx
@@ -6,7 +6,7 @@ interface AuthProviderProps {
   children: React.ReactNode;
 }
 
-const ACCESS_TOKEN_REFRESH_INTERVAL = 60 * 60 * 1000; // 만료 시간 1시간
+const ACCESS_TOKEN_REFRESH_INTERVAL = 1 * 30 * 1000; // 만료 시간 1시간
 const TOKEN_TIMESTAMP_KEY = 'lastTokenTime';
 
 export default function AuthProvider({ children }: AuthProviderProps) {
@@ -25,7 +25,7 @@ export default function AuthProvider({ children }: AuthProviderProps) {
 
   const refreshTokenRegularly = useCallback(async () => {
     try {
-      await refreshToken('web');
+      await refreshToken({ deviceType: 'web' });
       localStorage.setItem(TOKEN_TIMESTAMP_KEY, Date.now().toString());
     } catch (error) {
       console.error('Token refresh failed:', error);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -191,3 +191,13 @@ export type TokenResponse = {
   refreshToken: string;
   isNewUser: boolean;
 };
+
+export type LogoutRequest = {
+  deviceType: string;
+  refreshToken?: string;
+};
+
+export type ApiEmptyResponse = {
+  code: string;
+  content: Record<string, never>;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -186,6 +186,11 @@ export type OAuthLoginRequest = {
   deviceType: string;
 };
 
+export type ReIssueRequest = {
+  deviceType: string;
+  refreshToken?: string;
+};
+
 export type TokenResponse = {
   accessToken: string;
   refreshToken: string;


### PR DESCRIPTION
- [x] 로그아웃 타입 및 api 훅 추가
- [x] 토큰 갱신 api의 request 타입 변경
- [x] authProvider의 handleLogout 함수에 로그아웃 api 호출 추가
- [x] 로그인 성공 시 메인 헤더에 로그아웃 버튼 추가
- [x] 존재하지 않는 경로 접근 시 처리하는 Notfound 페이지 추가
- [x] 버튼 텍스트와 aria-label 불일치로 인한 접근성 문제 수정
  - ai 코드 리뷰 반영([WCAG 2.5.3](https://www.w3.org/WAI/WCAG22/Understanding/label-in-name.html) 참고)