### PR TITLE
[Articker - 21] 첫 회원가입 시 보여줄 joinPage 추가

### DIFF
--- a/src/api/hooks/useGetJoinTickerList.ts
+++ b/src/api/hooks/useGetJoinTickerList.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchInstance } from '../instance';
+import { ApiResponse, JoinTickerResponse } from '@/types';
+
+export const getJoinTickerListPath = () => `/api/v1/join/tickers`;
+
+export const getJoinTickerList = async (page: number) => {
+  const response = await fetchInstance.get<ApiResponse<JoinTickerResponse>>(
+    `${getJoinTickerListPath()}?page=${page}`
+  );
+  return response.data;
+};
+
+export const useGetJoinTickerList = (page: number) => {
+  return useQuery({
+    queryKey: ['joinTickerList', page],
+    queryFn: () => getJoinTickerList(page),
+    staleTime: 1000 * 60 * 5,
+  });
+};

--- a/src/api/hooks/usePutFavoriteTickers.ts
+++ b/src/api/hooks/usePutFavoriteTickers.ts
@@ -1,0 +1,20 @@
+import { useMutation } from '@tanstack/react-query';
+import { fetchInstance } from '../instance';
+
+import { FavoriteTickersRequest } from '@/types';
+
+export const putFavoriteTickersPath = () => `/api/v1/my/favorite/tickers`;
+
+const putFavoriteTickers = async ({ tickers }: FavoriteTickersRequest) => {
+  const response = await fetchInstance.put(putFavoriteTickersPath(), {
+    tickers,
+  });
+  return response.data;
+};
+
+export const usePutFavoriteTickers = () => {
+  return useMutation({
+    mutationFn: (favoriteTickersData: FavoriteTickersRequest) =>
+      putFavoriteTickers(favoriteTickersData),
+  });
+};

--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -59,12 +59,12 @@ const variantStyles = (variant: Props['variant'] = 'mint') => {
   }
   if (variant === 'blackOutline') {
     return {
-      boxShadow: '0 0 0 1px #000000 inset',
+      boxShadow: '0 0 0 1.4px #000000 inset',
       color: '#000000',
       background: 'none',
 
       '&:hover': {
-        backgroundColor: '#bac5db',
+        backgroundColor: '#f3f4f6',
       },
     };
   }
@@ -92,7 +92,7 @@ const variantStyles = (variant: Props['variant'] = 'mint') => {
   }
 
   return {
-    color: '#000',
+    color: '#ffffff',
     backgroundColor: '#0057FF',
     '&:hover': {
       backgroundColor: '#004ce4',

--- a/src/components/common/Layout/MainLayout.tsx
+++ b/src/components/common/Layout/MainLayout.tsx
@@ -39,13 +39,12 @@ export default function MainLayout() {
     }
   };
   const showHeader = scrollDirection === 'up' || scrollDirection === null;
-
-  // 바깥 클릭 시 메뉴 닫기
+  const isJoinPage = location.pathname === '/join';
 
   return (
     <Wrapper>
       <MainHeader ref={headerRef} onClick={handleHeaderClick} />
-      <SubHeader visible={showHeader} ref={subHeaderRef} />
+      {!isJoinPage && <SubHeader visible={showHeader} ref={subHeaderRef} />}
       <InnerWrapper>
         <QueryErrorResetBoundary>
           {({ reset }) => (

--- a/src/components/common/Layout/NoItem.tsx
+++ b/src/components/common/Layout/NoItem.tsx
@@ -1,0 +1,58 @@
+import styled from 'styled-components';
+import Logo from '@/assets/images/Articker.png';
+import { Paragraph } from '../typography/Paragraph';
+
+interface NoItemsMessageProps {
+  message?: string;
+  height?: number;
+  logo?: boolean;
+  alignItems?: string;
+}
+
+function NoItem({
+  message = '데이터가 없습니다!',
+  height,
+  logo = true,
+  alignItems,
+}: NoItemsMessageProps) {
+  return (
+    <MessageContainer height={height}>
+      <TextWrapper alignItems={alignItems}>
+        {logo && <LogoImage src={Logo} alt="아티커 로고" />}
+        <Paragraph size="xs" weight="normal">
+          {message}
+        </Paragraph>
+      </TextWrapper>
+    </MessageContainer>
+  );
+}
+
+const MessageContainer = styled.div<{ height?: number }>`
+  width: 100%;
+  margin: 20px 0;
+  align-content: center;
+  height: ${({ height }) => (height ? `${height}px` : 'auto')};
+`;
+const TextWrapper = styled.div<{ alignItems?: string }>`
+  display: flex;
+  flex-direction: column;
+  align-items: ${({ alignItems }) => alignItems || 'center'};
+  gap: 20px;
+  white-space: pre-line;
+  line-height: 26px;
+  p {
+    text-align: center;
+  }
+
+  @media screen and (max-width: 768px) {
+    gap: 10px;
+  }
+`;
+const LogoImage = styled.img`
+  height: 30px;
+
+  @media screen and (max-width: 768px) {
+    height: 20px;
+  }
+`;
+export default NoItem;

--- a/src/components/common/Modal/LoginModal.tsx
+++ b/src/components/common/Modal/LoginModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import * as ReactDOM from 'react-dom';
 import styled from 'styled-components';
 
@@ -6,12 +6,25 @@ import Logo from '@/assets/images/Articker.png';
 import GoogleLoginButton from '../Button/GoogleLoginButton';
 
 interface LoginModalProps {
-  children: (openModal: () => void) => React.ReactNode;
+  children?: (openModal: () => void) => React.ReactNode;
   currentPath: string;
+  immediateOpen?: boolean;
+  onClose?: () => void;
 }
 
-export default function LoginModal({ children, currentPath }: LoginModalProps) {
-  const [isOpen, setIsOpen] = useState(false);
+export default function LoginModal({
+  children,
+  currentPath,
+  immediateOpen = false,
+  onClose,
+}: LoginModalProps) {
+  const [isOpen, setIsOpen] = useState(immediateOpen);
+
+  useEffect(() => {
+    if (immediateOpen) {
+      setIsOpen(true);
+    }
+  }, [immediateOpen]);
 
   const openModal = () => {
     setIsOpen(true);
@@ -19,6 +32,9 @@ export default function LoginModal({ children, currentPath }: LoginModalProps) {
 
   const closeModal = () => {
     setIsOpen(false);
+    if (onClose) {
+      onClose();
+    }
   };
 
   const handleGoogleLogin = () => {

--- a/src/components/common/Pagination/index.tsx
+++ b/src/components/common/Pagination/index.tsx
@@ -1,0 +1,144 @@
+import { useMemo } from 'react';
+import styled from 'styled-components';
+import { IoChevronBack, IoChevronForward } from 'react-icons/io5';
+
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  totalItems?: number;
+  onPageChange: (page: number) => void;
+  itemsPerPage?: number;
+}
+
+export default function Pagination({
+  currentPage,
+  totalPages,
+  totalItems,
+  onPageChange,
+  itemsPerPage,
+}: PaginationProps) {
+  const shouldShowPagination = useMemo(() => {
+    if (itemsPerPage && totalItems) {
+      return totalItems > itemsPerPage;
+    }
+    return true;
+  }, [itemsPerPage, totalItems]);
+
+  const pageNumbers = useMemo(() => {
+    if (totalPages <= 5) {
+      return [...new Array(totalPages)].map((_, i) => i + 1);
+    }
+
+    let start = Math.max(currentPage - 2, 1);
+    const end = Math.min(start + 4, totalPages);
+
+    if (end === totalPages) {
+      start = Math.max(totalPages - 4, 1);
+    }
+
+    return [...new Array(end - start + 1)].map((_, i) => start + i);
+  }, [currentPage, totalPages]);
+
+  const isFirstPage = currentPage === 1;
+  const isLastPage = currentPage === totalPages;
+
+  const handlePageChange = (pageNum: number) => {
+    if (pageNum >= 1 && pageNum <= totalPages) {
+      onPageChange(pageNum);
+    }
+  };
+
+  if (!shouldShowPagination || totalPages <= 1) {
+    return null;
+  }
+
+  return (
+    <PaginationContainer>
+      <ArrowButton
+        aria-label="페이지네이션 왼쪽"
+        onClick={() => handlePageChange(currentPage - 1)}
+        disabled={isFirstPage}
+      >
+        <IoChevronBack size={20} />
+      </ArrowButton>
+      {pageNumbers.map((pageNum) => (
+        <PageNumber
+          key={pageNum}
+          aria-label={`${pageNum}_페이지`}
+          onClick={() => handlePageChange(pageNum)}
+          $active={pageNum === currentPage}
+        >
+          {pageNum}
+        </PageNumber>
+      ))}
+      <ArrowButton
+        aria-label="페이지네이션 오른쪽"
+        onClick={() => handlePageChange(currentPage + 1)}
+        disabled={isLastPage}
+      >
+        <IoChevronForward size={20} />
+      </ArrowButton>
+    </PaginationContainer>
+  );
+}
+
+const PaginationContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  padding: 20px 0;
+`;
+
+const ArrowButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  cursor: pointer;
+  background: transparent;
+  color: #333333;
+  box-shadow: none;
+  border: none;
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
+  svg {
+    display: block;
+  }
+`;
+
+interface PageNumberProps {
+  $active: boolean;
+}
+
+const PageNumber = styled.button<PageNumberProps>`
+  padding: 8px 12px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: ${(props) => {
+    if (!props.$active) return '#979797';
+    return 'black';
+  }};
+  cursor: pointer;
+
+  ${(props) =>
+    props.$active &&
+    `
+    background: #dee5f1;
+  `}
+
+  &:hover {
+    background: ${(props) => {
+      return props.$active ? '#dee5f1' : '#eef3fb';
+    }};
+    color: ${(props) => {
+      if (!props.$active) return '#626262';
+      return 'black';
+    }};
+  }
+`;

--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -102,7 +102,9 @@ export default function SearchBar({ onSearchResult }: SearchBarProps) {
           value={keyword}
           onChange={handleInputChange}
           onKeyDown={handleKeyDown}
-          onFocus={() => keyword.length >= 2 && setIsDropdownOpen(true)}
+          onFocus={() =>
+            !onSearchResult && keyword.length >= 2 && setIsDropdownOpen(true)
+          }
         />
         <SearchIcon
           size={24}
@@ -112,7 +114,7 @@ export default function SearchBar({ onSearchResult }: SearchBarProps) {
         />
       </Wrapper>
 
-      {isDropdownOpen && (
+      {isDropdownOpen && !onSearchResult && (
         <DropdownContainer>
           {isLoading ? (
             <DropdownItem>검색 중...</DropdownItem>

--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -1,10 +1,14 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { IoIosSearch } from 'react-icons/io';
 import { useGetTickerSearch } from '@/api/hooks/useGetTickerSearch';
 
-export default function SearchBar() {
+interface SearchBarProps {
+  onSearchResult?: (tickerCodes: string[] | null) => void;
+}
+
+export default function SearchBar({ onSearchResult }: SearchBarProps) {
   const [keyword, setKeyword] = useState('');
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(-1);
@@ -12,7 +16,10 @@ export default function SearchBar() {
   const navigate = useNavigate();
 
   const { data: searchData, isLoading } = useGetTickerSearch(keyword);
-  const tickerList = searchData?.content.tickerSearchList || [];
+  const tickerList = useMemo(
+    () => searchData?.content.tickerSearchList ?? [],
+    [searchData]
+  );
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -28,13 +35,23 @@ export default function SearchBar() {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
+  useEffect(() => {
+    if (!onSearchResult) return;
+    if (keyword.length < 2) {
+      onSearchResult(null);
+    } else {
+      onSearchResult(tickerList.map((t) => t.tickerCode));
+    }
+  }, [tickerList, keyword, onSearchResult]);
+
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setKeyword(value);
     setSelectedIndex(-1);
 
+    if (onSearchResult) return;
+
     if (value.length >= 2) {
-      // 2글자부터 드롭다운 열기
       setIsDropdownOpen(true);
     } else {
       setIsDropdownOpen(false);

--- a/src/components/common/TickerCard/index.tsx
+++ b/src/components/common/TickerCard/index.tsx
@@ -70,10 +70,10 @@ export default function TickerCard({
         </ImageContainer>
         <InfoContainer>
           <TickerInfo>
-            <Text size="s" weight="bold">
+            <Text size={isMobile ? 'xs' : 's'} weight="bold">
               {tickerCode}
             </Text>
-            <Text size="xxs" weight="normal" variant="grey">
+            <Text size={isMobile ? 'xxs' : 'xs'} weight="normal" variant="grey">
               {shortCompanyName}
             </Text>
           </TickerInfo>
@@ -123,9 +123,7 @@ const Wrapper = styled.div`
   padding: 12px;
 
   @media screen and (max-width: 768px) {
-    height: 100%;
-    aspect-ratio: 1.2 / 2;
-    width: auto;
+    width: 84%;
   }
 `;
 
@@ -152,6 +150,11 @@ const InfoContainer = styled.div`
   align-items: center;
   padding: 18px 0;
   gap: 10px;
+
+  @media screen and (max-width: 768px) {
+    padding: 16px 0;
+    gap: 8px;
+  }
 `;
 
 const TickerInfo = styled.div`
@@ -177,7 +180,7 @@ const LikeIcon = styled.div`
 
   @media screen and (max-width: 768px) {
     top: 8px;
-    right: 6px;
+    right: 0;
     svg {
       width: 24px;
       height: 24px;

--- a/src/components/common/TickerCard/index.tsx
+++ b/src/components/common/TickerCard/index.tsx
@@ -1,0 +1,202 @@
+import { PiHeartFill, PiHeartLight } from 'react-icons/pi';
+
+import styled from 'styled-components';
+
+import { useCallback, useState } from 'react';
+import { Text } from '@/components/common/typography/Text';
+import { JoinTickerData } from '@/types';
+import useAuth from '@/hooks/useAuth';
+import useIsMobile from '@/hooks/useIsMobile';
+import useGetVariant from '@/hooks/useGetVariant';
+import useGetSignSymbol from '@/hooks/useGetSignSymbol';
+import GraphView from '@/components/Ticker/ABTest/GraphView';
+import LoginModal from '@/components/common/Modal/LoginModal';
+import { useLocation } from 'react-router-dom';
+
+interface TickerCardProps extends JoinTickerData {
+  onToggleLike: (tickerId: string, isFavorite: boolean) => void;
+  isSelected: boolean;
+}
+
+export default function TickerCard({
+  tickerCode,
+  shortCompanyName,
+  predictionStrategy,
+  sentiment,
+  graphData,
+  onToggleLike,
+  isSelected = false,
+}: TickerCardProps) {
+  const isMobile = useIsMobile();
+  const getVariant = useGetVariant(sentiment);
+  const getSignSymbol = useGetSignSymbol(sentiment);
+  const { isAuthenticated } = useAuth();
+  const location = useLocation();
+  const [showLoginModal, setShowLoginModal] = useState(false);
+
+  const handleLikeClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      event.stopPropagation();
+      event.preventDefault();
+      if (!isAuthenticated) {
+        setShowLoginModal(true);
+        return;
+      }
+      onToggleLike(tickerCode, !isSelected);
+    },
+    [tickerCode, isSelected, onToggleLike, isAuthenticated]
+  );
+
+  return (
+    <>
+      <Wrapper>
+        <ImageContainer>
+          <LikeIcon onClick={handleLikeClick}>
+            {isSelected ? (
+              <PiHeartFill color="#fe7373" size={32} />
+            ) : (
+              <PiHeartLight
+                size={32}
+                color="white"
+                style={{
+                  filter: 'drop-shadow(0px 0px 1px rgba(0, 0, 0, 0.3))',
+                }}
+              />
+            )}
+          </LikeIcon>
+          <GraphWrapper>
+            <GraphView graphData={graphData} />
+          </GraphWrapper>
+        </ImageContainer>
+        <InfoContainer>
+          <TickerInfo>
+            <Text size="s" weight="bold">
+              {tickerCode}
+            </Text>
+            <Text size="xxs" weight="normal" variant="grey">
+              {shortCompanyName}
+            </Text>
+          </TickerInfo>
+          <SignalInfo>
+            {getSignSymbol && (
+              <span
+                style={{
+                  marginRight: '4px',
+                  fontSize: isMobile ? '12px' : '14px',
+                }}
+              >
+                {getSignSymbol}
+              </span>
+            )}
+            <Text
+              size={isMobile ? 'xxs' : 'xs'}
+              weight="bold"
+              variant={getVariant}
+            >
+              {predictionStrategy} 신호
+            </Text>
+          </SignalInfo>
+        </InfoContainer>
+      </Wrapper>
+      {showLoginModal && (
+        <LoginModal
+          immediateOpen={true}
+          currentPath={location.pathname}
+          onClose={() => setShowLoginModal(false)}
+        />
+      )}
+    </>
+  );
+}
+
+const Wrapper = styled.div`
+  width: 154px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  text-decoration: none;
+  gap: 4px;
+  border-radius: 8px;
+
+  background-color: #f7faff;
+  padding: 12px;
+
+  @media screen and (max-width: 768px) {
+    height: 100%;
+    aspect-ratio: 1.2 / 2;
+    width: auto;
+  }
+`;
+
+const ImageContainer = styled.div`
+  width: 150px;
+  aspect-ratio: 3 / 2;
+  position: relative;
+  border-radius: 6px;
+  overflow: hidden;
+
+  margin-bottom: 4px;
+
+  @media screen and (max-width: 768px) {
+    width: 100%;
+  }
+`;
+
+const InfoContainer = styled.div`
+  background-color: rgb(255, 255, 255);
+  border-radius: 8px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 18px 0;
+  gap: 10px;
+`;
+
+const TickerInfo = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  gap: 8px;
+`;
+
+const SignalInfo = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const LikeIcon = styled.div`
+  position: absolute;
+  width: 30px;
+  height: 30px;
+  right: 2px;
+  top: 4px;
+  z-index: 100;
+  cursor: pointer;
+
+  @media screen and (max-width: 768px) {
+    top: 8px;
+    right: 6px;
+    svg {
+      width: 24px;
+      height: 24px;
+    }
+  }
+`;
+
+const GraphWrapper = styled.div`
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 60%;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+
+  > div {
+    padding: 0 !important;
+    height: 100% !important;
+  }
+`;

--- a/src/components/common/TickerCard/index.tsx
+++ b/src/components/common/TickerCard/index.tsx
@@ -172,7 +172,7 @@ const LikeIcon = styled.div`
   height: 30px;
   right: 2px;
   top: 4px;
-  z-index: 100;
+  z-index: 9;
   cursor: pointer;
 
   @media screen and (max-width: 768px) {

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -4,13 +4,15 @@ import { detailHandlers } from './detailHandlers';
 import newsHandlers from './newsHandler';
 import { searchHandlers } from './searchHandler';
 import { articleDetailHandlers } from './articleDetailHandler';
+import { joinHandlers } from './joinHandler';
 
 export const worker = setupWorker(
   ...mainHandlers,
   ...detailHandlers,
   ...newsHandlers,
   ...searchHandlers,
-  ...articleDetailHandlers
+  ...articleDetailHandlers,
+  ...joinHandlers
 );
 
 export default worker;

--- a/src/mocks/joinHandler.ts
+++ b/src/mocks/joinHandler.ts
@@ -1,0 +1,158 @@
+import { http, HttpResponse } from 'msw';
+import { BASE_URL } from '@/api/instance';
+import { getJoinTickerListPath } from '@/api/hooks/useGetJoinTickerList';
+
+const mockTickerData = [
+  {
+    tickerCode: 'GOOGL',
+    shortCompanyName: 'Google',
+    predictionStrategy: '약한매수',
+    sentiment: 1,
+  },
+  {
+    tickerCode: 'AAPL',
+    shortCompanyName: 'Apple',
+    predictionStrategy: '관망',
+    sentiment: 0,
+  },
+  {
+    tickerCode: 'META',
+    shortCompanyName: 'Meta',
+    predictionStrategy: '약한매수',
+    sentiment: 1,
+  },
+  {
+    tickerCode: 'NFLX',
+    shortCompanyName: 'Netflix',
+    predictionStrategy: '강한매수',
+    sentiment: 1,
+  },
+  {
+    tickerCode: 'COIN',
+    shortCompanyName: 'Coinbase',
+    predictionStrategy: '약한매도',
+    sentiment: -1,
+  },
+  {
+    tickerCode: 'NVDA',
+    shortCompanyName: 'NVIDIA',
+    predictionStrategy: '강한매도',
+    sentiment: -1,
+  },
+  {
+    tickerCode: 'TSLA',
+    shortCompanyName: 'Tesla',
+    predictionStrategy: '강한매수',
+    sentiment: 1,
+  },
+  {
+    tickerCode: 'AMZN',
+    shortCompanyName: 'Amazon',
+    predictionStrategy: '관망',
+    sentiment: 0,
+  },
+  {
+    tickerCode: 'PYPL',
+    shortCompanyName: 'PayPal',
+    predictionStrategy: '약한매도',
+    sentiment: -1,
+  },
+  {
+    tickerCode: 'ZM',
+    shortCompanyName: 'Zoom',
+    predictionStrategy: '관망',
+    sentiment: 0,
+  },
+  {
+    tickerCode: 'MSFT',
+    shortCompanyName: 'Microsoft',
+    predictionStrategy: '강한매수',
+    sentiment: 1,
+  },
+  {
+    tickerCode: 'AMD',
+    shortCompanyName: 'AMD',
+    predictionStrategy: '약한매수',
+    sentiment: 1,
+  },
+  {
+    tickerCode: 'PLTR',
+    shortCompanyName: 'Palantir',
+    predictionStrategy: '관망',
+    sentiment: 0,
+  },
+  {
+    tickerCode: 'SPOT',
+    shortCompanyName: 'Spotify',
+    predictionStrategy: '약한매도',
+    sentiment: -1,
+  },
+  {
+    tickerCode: 'SHOP',
+    shortCompanyName: 'Shopify',
+    predictionStrategy: '강한매도',
+    sentiment: -1,
+  },
+  {
+    tickerCode: 'UBER',
+    shortCompanyName: 'Uber',
+    predictionStrategy: '약한매수',
+    sentiment: 1,
+  },
+  {
+    tickerCode: 'ABNB',
+    shortCompanyName: 'Airbnb',
+    predictionStrategy: '관망',
+    sentiment: 0,
+  },
+  {
+    tickerCode: 'SQ',
+    shortCompanyName: 'Block',
+    predictionStrategy: '약한매도',
+    sentiment: -1,
+  },
+];
+
+export const tickerHandlers = [
+  http.get(`${BASE_URL}${getJoinTickerListPath()}`, ({ request }) => {
+    const url = new URL(request.url);
+    const page = parseInt(url.searchParams.get('page') || '0');
+    const pageSize = 9;
+    const totalItems = mockTickerData.length;
+    const totalPages = Math.ceil(totalItems / pageSize);
+
+    const startIndex = page * pageSize;
+    const endIndex = startIndex + pageSize;
+    const pageData = mockTickerData.slice(startIndex, endIndex);
+
+    const tickers = pageData.map((item) => {
+      const isMarketOpen = Math.random() > 0.5;
+      const priceData = isMarketOpen
+        ? [
+            177.82, 182.55, 178.88, 180.64, 186.52, 181.36, 186.6, 190.17,
+            186.86, 193.8, 193.16,
+          ]
+        : [
+            476.99, 474, 472.12, 478.43, 487.12, 493.79, 507.49, 510.18, 503.29,
+            511.14, 508.68,
+          ];
+
+      return {
+        ...item,
+        graphData: { isMarketOpen, priceData },
+      };
+    });
+
+    return HttpResponse.json({
+      code: '200 OK',
+      message: '종목 리스트 조회 성공',
+      content: {
+        tickers,
+        pageNumber: page,
+        hasNext: page < totalPages - 1,
+      },
+    });
+  }),
+];
+
+export const joinHandlers = [...tickerHandlers];

--- a/src/mocks/server.ts
+++ b/src/mocks/server.ts
@@ -4,12 +4,14 @@ import { detailHandlers } from './detailHandlers';
 import newsHandlers from './newsHandler';
 import { searchHandlers } from './searchHandler';
 import { articleDetailHandlers } from './articleDetailHandler';
+import { joinHandlers } from './joinHandler';
 
 const server = setupServer(
   ...mainHandlers,
   ...detailHandlers,
   ...newsHandlers,
   ...searchHandlers,
-  ...articleDetailHandlers
+  ...articleDetailHandlers,
+  ...joinHandlers
 );
 export default server;

--- a/src/pages/Join/index.tsx
+++ b/src/pages/Join/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { Paragraph } from '@/components/common/typography/Paragraph';
@@ -23,7 +23,6 @@ export default function JoinPage() {
   const [searchResultCodes, setSearchResultCodes] = useState<string[] | null>(
     null
   );
-  const [totalPages, setTotalPages] = useState(4);
   const { data } = useGetJoinTickerList(currentPage - 1);
   const tickerList = data?.content.tickers || [];
   const filteredTickers =
@@ -32,14 +31,8 @@ export default function JoinPage() {
           searchResultCodes.includes(ticker.tickerCode)
         )
       : tickerList;
-
-  useEffect(() => {
-    if (searchResultCodes !== null) {
-      setTotalPages(Math.ceil(filteredTickers.length / 9) || 1);
-    } else {
-      setTotalPages(4);
-    }
-  }, [searchResultCodes, filteredTickers.length]);
+  const totalPages =
+    searchResultCodes !== null ? Math.ceil(filteredTickers.length / 9) || 1 : 4;
 
   const handlePageChange = (pageNum: number) => {
     setCurrentPage(pageNum);

--- a/src/pages/Join/index.tsx
+++ b/src/pages/Join/index.tsx
@@ -31,8 +31,12 @@ export default function JoinPage() {
           searchResultCodes.includes(ticker.tickerCode)
         )
       : tickerList;
+  const itemSize = isMobile ? 8 : 9;
+  const displayTickers = filteredTickers.slice(0, itemSize);
   const totalPages =
-    searchResultCodes !== null ? Math.ceil(filteredTickers.length / 9) || 1 : 4;
+    searchResultCodes !== null
+      ? Math.ceil(filteredTickers.length / itemSize) || 1
+      : 4;
 
   const handlePageChange = (pageNum: number) => {
     setCurrentPage(pageNum);
@@ -93,7 +97,7 @@ export default function JoinPage() {
         />
       ) : (
         <CardContainer>
-          {filteredTickers.map((ticker) => (
+          {displayTickers.map((ticker) => (
             <TickerCard
               key={ticker.tickerCode}
               tickerCode={ticker.tickerCode}
@@ -148,6 +152,11 @@ const CardContainer = styled.div`
   grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
   gap: 20px;
   margin-top: 10px;
+
+  @media screen and (max-width: 768px) {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px;
+  }
 `;
 
 const ButtonWrapper = styled.div`
@@ -158,6 +167,7 @@ const ButtonWrapper = styled.div`
   margin-bottom: 30px;
 
   @media screen and (max-width: 768px) {
+    width: 90%;
     margin-bottom: 20px;
   }
 `;

--- a/src/pages/Join/index.tsx
+++ b/src/pages/Join/index.tsx
@@ -1,23 +1,149 @@
-import { useEffect } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import useAuth from '@/hooks/useAuth';
+import styled from 'styled-components';
+import { Paragraph } from '@/components/common/typography/Paragraph';
+import { Text } from '@/components/common/typography/Text';
+import TickerCard from '@/components/common/TickerCard';
+import Pagination from '@/components/common/Pagination';
+import NoItem from '@/components/common/Layout/NoItem';
+import Button from '@/components/common/Button';
+import { useGetJoinTickerList } from '@/api/hooks/useGetJoinTickerList';
+import { usePutFavoriteTickers } from '@/api/hooks/usePutFavoriteTickers';
+import useIsMobile from '@/hooks/useIsMobile';
 
 export default function JoinPage() {
   const navigate = useNavigate();
-  const { isAuthenticated } = useAuth();
+  const isMobile = useIsMobile();
+  const [selectedTickers, setSelectedTickers] = useState<Set<string>>(
+    new Set()
+  );
+  const { mutateAsync: postMultipleLikes } = usePutFavoriteTickers();
+  const [currentPage, setCurrentPage] = useState(1);
+  const TOTAL_PAGES = 4;
+  const { data } = useGetJoinTickerList(currentPage - 1);
+  const tickerList = data?.content.tickers || [];
 
-  // to-do: 추후 초기 설정 컴포넌트 추가해야 됨
-  useEffect(() => {
-    if (isAuthenticated) {
-      const redirectPath = localStorage.getItem('redirectPath');
-      if (redirectPath) {
-        localStorage.removeItem('redirectPath');
-        navigate(redirectPath, { replace: true });
-      } else {
-        navigate('/', { replace: true });
+  const handlePageChange = (pageNum: number) => {
+    setCurrentPage(pageNum);
+  };
+
+  const handleSkip = () => {
+    navigate('/');
+  };
+
+  const handleStart = async () => {
+    try {
+      if (selectedTickers.size > 0) {
+        await postMultipleLikes({
+          tickers: [...selectedTickers],
+        });
       }
+    } catch (error) {
+      console.error('좋아요 처리 중 오류 발생:', error);
+    } finally {
+      navigate('/');
     }
-  }, [isAuthenticated, navigate]);
+  };
 
-  return null;
+  const handleToggleLike = (tickerCode: string, isFavorite: boolean) => {
+    setSelectedTickers((prev) => {
+      const newSet = new Set(prev);
+      if (isFavorite) {
+        newSet.add(tickerCode);
+      } else {
+        newSet.delete(tickerCode);
+      }
+      return newSet;
+    });
+  };
+
+  const buttonStyle = {
+    width: isMobile ? '140px' : '170px',
+    height: isMobile ? '40px' : '46px',
+    fontSize: isMobile ? '16px' : '18px',
+  };
+
+  return (
+    <Wrapper>
+      <Paragraph size="m" weight="bold">
+        관심 있는
+        <Text size="l" weight="bold" variant="blue">
+          종목
+        </Text>
+        을 선택하세요!
+      </Paragraph>
+      {tickerList.length === 0 ? (
+        <NoItem
+          message="종목 정보가 없어요!"
+          height={300}
+          alignItems="center"
+        />
+      ) : (
+        <CardContainer>
+          {tickerList.map((ticker) => (
+            <TickerCard
+              key={ticker.tickerCode}
+              tickerCode={ticker.tickerCode}
+              shortCompanyName={ticker.shortCompanyName}
+              predictionStrategy={ticker.predictionStrategy}
+              sentiment={ticker.sentiment}
+              graphData={ticker.graphData}
+              onToggleLike={handleToggleLike}
+              isSelected={selectedTickers.has(ticker.tickerCode)}
+            />
+          ))}
+        </CardContainer>
+      )}
+      <Pagination
+        currentPage={currentPage}
+        totalPages={TOTAL_PAGES}
+        onPageChange={handlePageChange}
+      />
+      <ButtonWrapper>
+        <Button
+          aria-label="건너뛰기"
+          variant="blackOutline"
+          style={buttonStyle}
+          onClick={handleSkip}
+        >
+          건너뛰기
+        </Button>
+        <Button
+          aria-label="시작하기"
+          variant="mint"
+          style={buttonStyle}
+          onClick={handleStart}
+        >
+          시작하기
+        </Button>
+      </ButtonWrapper>
+    </Wrapper>
+  );
 }
+
+const Wrapper = styled.div`
+  width: 90%;
+  display: flex;
+  flex-direction: column;
+  margin: 0 auto;
+  padding: 20px;
+`;
+
+const CardContainer = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+  gap: 20px;
+  margin-top: 20px;
+`;
+
+const ButtonWrapper = styled.div`
+  width: 630px;
+  display: flex;
+  justify-content: space-between;
+  gap: 180px;
+  margin-bottom: 30px;
+
+  @media screen and (max-width: 768px) {
+    margin-bottom: 20px;
+  }
+`;

--- a/src/pages/Join/index.tsx
+++ b/src/pages/Join/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { Paragraph } from '@/components/common/typography/Paragraph';
@@ -10,6 +10,7 @@ import Button from '@/components/common/Button';
 import { useGetJoinTickerList } from '@/api/hooks/useGetJoinTickerList';
 import { usePutFavoriteTickers } from '@/api/hooks/usePutFavoriteTickers';
 import useIsMobile from '@/hooks/useIsMobile';
+import SearchBar from '@/components/common/SearchBar';
 
 export default function JoinPage() {
   const navigate = useNavigate();
@@ -19,9 +20,26 @@ export default function JoinPage() {
   );
   const { mutateAsync: postMultipleLikes } = usePutFavoriteTickers();
   const [currentPage, setCurrentPage] = useState(1);
-  const TOTAL_PAGES = 4;
+  const [searchResultCodes, setSearchResultCodes] = useState<string[] | null>(
+    null
+  );
+  const [totalPages, setTotalPages] = useState(4);
   const { data } = useGetJoinTickerList(currentPage - 1);
   const tickerList = data?.content.tickers || [];
+  const filteredTickers =
+    searchResultCodes !== null
+      ? tickerList.filter((ticker) =>
+          searchResultCodes.includes(ticker.tickerCode)
+        )
+      : tickerList;
+
+  useEffect(() => {
+    if (searchResultCodes !== null) {
+      setTotalPages(Math.ceil(filteredTickers.length / 9) || 1);
+    } else {
+      setTotalPages(4);
+    }
+  }, [searchResultCodes, filteredTickers.length]);
 
   const handlePageChange = (pageNum: number) => {
     setCurrentPage(pageNum);
@@ -72,7 +90,8 @@ export default function JoinPage() {
         </Text>
         을 선택하세요!
       </Paragraph>
-      {tickerList.length === 0 ? (
+      <SearchBar onSearchResult={setSearchResultCodes} />
+      {filteredTickers.length === 0 ? (
         <NoItem
           message="종목 정보가 없어요!"
           height={300}
@@ -80,7 +99,7 @@ export default function JoinPage() {
         />
       ) : (
         <CardContainer>
-          {tickerList.map((ticker) => (
+          {filteredTickers.map((ticker) => (
             <TickerCard
               key={ticker.tickerCode}
               tickerCode={ticker.tickerCode}
@@ -96,7 +115,7 @@ export default function JoinPage() {
       )}
       <Pagination
         currentPage={currentPage}
-        totalPages={TOTAL_PAGES}
+        totalPages={totalPages}
         onPageChange={handlePageChange}
       />
       <ButtonWrapper>
@@ -127,13 +146,14 @@ const Wrapper = styled.div`
   flex-direction: column;
   margin: 0 auto;
   padding: 20px;
+  gap: 20px;
 `;
 
 const CardContainer = styled.div`
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
   gap: 20px;
-  margin-top: 20px;
+  margin-top: 10px;
 `;
 
 const ButtonWrapper = styled.div`

--- a/src/pages/Join/index.tsx
+++ b/src/pages/Join/index.tsx
@@ -51,6 +51,7 @@ export default function JoinPage() {
       }
     } catch (error) {
       console.error('좋아요 처리 중 오류 발생:', error);
+      alert('관심 종목 저장에 실패했습니다. 다시 시도해주세요!');
     } finally {
       navigate('/');
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -220,3 +220,7 @@ export type JoinTickerResponse = {
   pageNumber: number;
   hasNext: boolean;
 };
+
+export type FavoriteTickersRequest = {
+  tickers: string[];
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -206,3 +206,17 @@ export type ApiEmptyResponse = {
   code: string;
   content: Record<string, never>;
 };
+
+export type JoinTickerData = {
+  tickerCode: string;
+  shortCompanyName: string;
+  predictionStrategy: string;
+  sentiment: number;
+  graphData: PredictionListGraphDataResponse;
+};
+
+export type JoinTickerResponse = {
+  tickers: JoinTickerData[];
+  pageNumber: number;
+  hasNext: boolean;
+};


### PR DESCRIPTION
- 기능 추가
- [x] 회원 가입 페이지(join) - 종목 리스트 조회 api 훅 추가
- [x] 회원 가입 페이지(join) - 종목 리스트 조회 mock 핸들러 추가
- [x] 회원 가입 페이지(join) - 관심 종목 수정 api 훅 추가
- [x] 관심 종목 보여주는 tickerCard 컴포넌트 구현
- [x] 첫 회원가입 시 관심종목 선택하는 joinPage 구현
- [x] 로그인 모달 바로 띄울 수 있도록 immediateOpen prop 추가
- [x] join 페이지에 검색바 추가
</br>

- 기능 개선
- [x] join 페이지에선 search 결과값(드롭다운)이 안 보이도록 조건 추가
- [x] totalPages를 useState에서 렌더 중일 때 계산되는 값으로 전환해 불필요한 리렌더링 제거