### PR TITLE
[Articker - 25] 종목 및 뉴스 기사 좋아요 기능 추가

### DIFF
--- a/src/components/Article/ArticleItem.tsx
+++ b/src/components/Article/ArticleItem.tsx
@@ -40,18 +40,6 @@ export default function NewsItem({ item }: { item: ArticleDataResponse }) {
     [isFavorite, isAuthenticated, item.articleId, putFavoriteArticle]
   );
 
-  // const getSentimentInfo = () => {
-  //   if (item.sentiment === 'positive') {
-  //     return { label: '긍정', emoji: '📈', color: '#ef4444' };
-  //   } else if (item.sentiment === 'negative') {
-  //     return { label: '부정', emoji: '📉', color: '#3b82f6' };
-  //   } else {
-  //     return { label: '중립', emoji: '➖', color: '#6b7280' };
-  //   }
-  // };
-
-  // const sentimentInfo = getSentimentInfo();
-
   return (
     <>
       <Wrapper onClick={handleClick}>
@@ -95,14 +83,6 @@ export default function NewsItem({ item }: { item: ArticleDataResponse }) {
               </>
             ) : (
               <>
-                {/* {item.sentiment !== null && (
-                  <SentimentTag $color={sentimentInfo.color}>
-                    <span>{sentimentInfo.emoji}</span>
-                    <Text size="xs" weight="bold">
-                      {sentimentInfo.label}
-                    </Text>
-                  </SentimentTag>
-                )} */}
                 <CompanyContainer>
                   {item.shortCompanyNames?.slice(0, 5).map((company) => (
                     <CompanyTag key={company}>
@@ -240,23 +220,3 @@ const LikeIconWrapper = styled.div`
   line-height: 1;
   z-index: 1;
 `;
-
-// const SentimentTag = styled.div<{ $color: string }>`
-//   display: inline-flex;
-//   align-items: center;
-//   gap: 4px;
-//   padding: 6px 8px 4px 8px;
-//   background-color: ${(props) => props.$color}15;
-//   border: 1px solid ${(props) => props.$color}40;
-//   border-radius: 12px;
-//   white-space: nowrap;
-//   flex-shrink: 0;
-
-//   span {
-//     font-size: 12px;
-//   }
-
-//   & > *:last-child {
-//     color: ${(props) => props.$color} !important;
-//   }
-// `;

--- a/src/components/Article/ArticleItem.tsx
+++ b/src/components/Article/ArticleItem.tsx
@@ -3,14 +3,42 @@ import { Text } from '../common/typography/Text';
 import { ArticleDataResponse } from '@/types';
 import FallbackImage from '../common/Item/FallbackImage';
 import useIsMobile from '@/hooks/useIsMobile';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useState, useCallback } from 'react';
+import { PiHeartFill, PiHeartLight } from 'react-icons/pi';
+import useAuth from '@/hooks/useAuth';
+import { usePutFavoriteArticle } from '@/api/hooks/usePutFavoriteArticle';
+import LoginModal from '@/components/common/Modal/LoginModal';
 
 export default function NewsItem({ item }: { item: ArticleDataResponse }) {
   const isMobile = useIsMobile();
   const navigate = useNavigate();
+  const location = useLocation();
+  const { isAuthenticated } = useAuth();
+  const [isFavorite, setIsFavorite] = useState(item.isFavorite ?? false);
+  const [showLoginModal, setShowLoginModal] = useState(false);
+  const { mutate: putFavoriteArticle } = usePutFavoriteArticle();
+
   const handleClick = () => {
     navigate(`/news/${item.articleId}`);
   };
+
+  const handleLikeClick = useCallback(
+    (event: React.MouseEvent) => {
+      event.stopPropagation();
+      if (!isAuthenticated) {
+        setShowLoginModal(true);
+        return;
+      }
+      const nextFavorite = !isFavorite;
+      setIsFavorite(nextFavorite);
+      putFavoriteArticle({
+        articleId: item.articleId,
+        mode: nextFavorite ? 'on' : 'off',
+      });
+    },
+    [isFavorite, isAuthenticated, item.articleId, putFavoriteArticle]
+  );
 
   // const getSentimentInfo = () => {
   //   if (item.sentiment === 'positive') {
@@ -25,77 +53,94 @@ export default function NewsItem({ item }: { item: ArticleDataResponse }) {
   // const sentimentInfo = getSentimentInfo();
 
   return (
-    <Wrapper onClick={handleClick}>
-      <NewsContent>
-        <ImageContainer>
-          <FallbackImage src={item.thumbnailUrl} alt={item.title} />
-        </ImageContainer>
-        <TextContainer>
-          <TitleText size={isMobile ? 'xs' : 'm'} weight="bold">
-            {item.title}
-          </TitleText>
-          {isMobile ? (
-            <>
-              <CompanyContainer>
-                {item.shortCompanyNames?.slice(0, 2).map((company) => (
-                  <CompanyTag key={company}>
-                    <Text size="12px" weight="normal">
-                      {company}
-                    </Text>
-                  </CompanyTag>
-                ))}
-                {item.shortCompanyNames &&
-                  item.shortCompanyNames.length > 2 && (
-                    <CompanyTag>
-                      <Text size="12px" weight="normal">
-                        ...
-                      </Text>
-                    </CompanyTag>
-                  )}
-              </CompanyContainer>
-              <Text size="12px" weight="normal" variant="grey">
-                {item.publishedDate}
-              </Text>
-            </>
+    <>
+      <Wrapper onClick={handleClick}>
+        <LikeIconWrapper onClick={handleLikeClick}>
+          {isFavorite ? (
+            <PiHeartFill color="#fe7373" size={isMobile ? 18 : 22} />
           ) : (
-            <>
-              {/* {item.sentiment !== null && (
-                <SentimentTag $color={sentimentInfo.color}>
-                  <span>{sentimentInfo.emoji}</span>
-                  <Text size="xs" weight="bold">
-                    {sentimentInfo.label}
-                  </Text>
-                </SentimentTag>
-              )} */}
-              <CompanyContainer>
-                {item.shortCompanyNames?.slice(0, 5).map((company) => (
-                  <CompanyTag key={company}>
-                    <Text size="xs" weight="normal">
-                      {company}
-                    </Text>
-                  </CompanyTag>
-                ))}
-                {item.shortCompanyNames &&
-                  item.shortCompanyNames.length > 4 && (
-                    <CompanyTag>
-                      <Text size="xs" weight="normal">
-                        ...
+            <PiHeartLight size={isMobile ? 18 : 22} color="#ccc" />
+          )}
+        </LikeIconWrapper>
+        <NewsContent>
+          <ImageContainer>
+            <FallbackImage src={item.thumbnailUrl} alt={item.title} />
+          </ImageContainer>
+          <TextContainer>
+            <TitleText size={isMobile ? 'xs' : 'm'} weight="bold">
+              {item.title}
+            </TitleText>
+            {isMobile ? (
+              <>
+                <CompanyContainer>
+                  {item.shortCompanyNames?.slice(0, 2).map((company) => (
+                    <CompanyTag key={company}>
+                      <Text size="12px" weight="normal">
+                        {company}
                       </Text>
                     </CompanyTag>
-                  )}
-              </CompanyContainer>
-              <Text size="xs" weight="normal" variant="grey">
-                {item.publishedDate}
-              </Text>
-            </>
-          )}
-        </TextContainer>
-      </NewsContent>
-    </Wrapper>
+                  ))}
+                  {item.shortCompanyNames &&
+                    item.shortCompanyNames.length > 2 && (
+                      <CompanyTag>
+                        <Text size="12px" weight="normal">
+                          ...
+                        </Text>
+                      </CompanyTag>
+                    )}
+                </CompanyContainer>
+                <Text size="12px" weight="normal" variant="grey">
+                  {item.publishedDate}
+                </Text>
+              </>
+            ) : (
+              <>
+                {/* {item.sentiment !== null && (
+                  <SentimentTag $color={sentimentInfo.color}>
+                    <span>{sentimentInfo.emoji}</span>
+                    <Text size="xs" weight="bold">
+                      {sentimentInfo.label}
+                    </Text>
+                  </SentimentTag>
+                )} */}
+                <CompanyContainer>
+                  {item.shortCompanyNames?.slice(0, 5).map((company) => (
+                    <CompanyTag key={company}>
+                      <Text size="xs" weight="normal">
+                        {company}
+                      </Text>
+                    </CompanyTag>
+                  ))}
+                  {item.shortCompanyNames &&
+                    item.shortCompanyNames.length > 4 && (
+                      <CompanyTag>
+                        <Text size="xs" weight="normal">
+                          ...
+                        </Text>
+                      </CompanyTag>
+                    )}
+                </CompanyContainer>
+                <Text size="xs" weight="normal" variant="grey">
+                  {item.publishedDate}
+                </Text>
+              </>
+            )}
+          </TextContainer>
+        </NewsContent>
+      </Wrapper>
+      {showLoginModal && (
+        <LoginModal
+          immediateOpen={true}
+          currentPath={location.pathname}
+          onClose={() => setShowLoginModal(false)}
+        />
+      )}
+    </>
   );
 }
 
 const Wrapper = styled.div`
+  position: relative;
   display: flex;
   flex-direction: column;
   padding: 20px 30px;
@@ -183,6 +228,17 @@ const CompanyTag = styled.div`
   span {
     color: #374151 !important;
   }
+`;
+
+const LikeIconWrapper = styled.div`
+  position: absolute;
+  top: 12px;
+  right: 16px;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  line-height: 1;
+  z-index: 1;
 `;
 
 // const SentimentTag = styled.div<{ $color: string }>`

--- a/src/components/Article/ArticleItem.tsx
+++ b/src/components/Article/ArticleItem.tsx
@@ -32,10 +32,15 @@ export default function NewsItem({ item }: { item: ArticleDataResponse }) {
       }
       const nextFavorite = !isFavorite;
       setIsFavorite(nextFavorite);
-      putFavoriteArticle({
-        articleId: item.articleId,
-        mode: nextFavorite ? 'on' : 'off',
-      });
+      putFavoriteArticle(
+        { articleId: item.articleId, mode: nextFavorite ? 'on' : 'off' },
+        {
+          onError: () => {
+            setIsFavorite(!nextFavorite);
+            alert('스크랩 처리에 실패했습니다. 다시 시도해주세요.');
+          },
+        }
+      );
     },
     [isFavorite, isAuthenticated, item.articleId, putFavoriteArticle]
   );

--- a/src/components/Article/ArticleItem.tsx
+++ b/src/components/Article/ArticleItem.tsx
@@ -66,8 +66,8 @@ export default function NewsItem({ item }: { item: ArticleDataResponse }) {
             {isMobile ? (
               <>
                 <CompanyContainer>
-                  {item.shortCompanyNames?.slice(0, 2).map((company) => (
-                    <CompanyTag key={company}>
+                  {item.shortCompanyNames?.slice(0, 2).map((company, i) => (
+                    <CompanyTag key={`${company}-${i}`}>
                       <Text size="12px" weight="normal">
                         {company}
                       </Text>
@@ -89,8 +89,8 @@ export default function NewsItem({ item }: { item: ArticleDataResponse }) {
             ) : (
               <>
                 <CompanyContainer>
-                  {item.shortCompanyNames?.slice(0, 5).map((company) => (
-                    <CompanyTag key={company}>
+                  {item.shortCompanyNames?.slice(0, 5).map((company, i) => (
+                    <CompanyTag key={`${company}-${i}`}>
                       <Text size="xs" weight="normal">
                         {company}
                       </Text>

--- a/src/components/Ticker/TickerItem.tsx
+++ b/src/components/Ticker/TickerItem.tsx
@@ -33,10 +33,15 @@ export default function TickerItem({ item }: { item: PredictionDataResponse }) {
       }
       const nextFavorite = !isFavorite;
       setIsFavorite(nextFavorite);
-      putFavoriteTicker({
-        tickerCode: item.tickerCode,
-        mode: nextFavorite ? 'on' : 'off',
-      });
+      putFavoriteTicker(
+        { tickerCode: item.tickerCode, mode: nextFavorite ? 'on' : 'off' },
+        {
+          onError: () => {
+            setIsFavorite(!nextFavorite);
+            alert('좋아요 처리에 실패했습니다. 다시 시도해주세요.');
+          },
+        }
+      );
     },
     [isFavorite, isAuthenticated, item.tickerCode, putFavoriteTicker]
   );

--- a/src/components/Ticker/TickerItem.tsx
+++ b/src/components/Ticker/TickerItem.tsx
@@ -6,48 +6,93 @@ import useGetVariant from '@/hooks/useGetVariant';
 import useGetSignSymbol from '@/hooks/useGetSignSymbol';
 import useIsMobile from '@/hooks/useIsMobile';
 import GraphView from './ABTest/GraphView';
+import { useCallback, useState } from 'react';
+import { PiHeartFill, PiHeartLight } from 'react-icons/pi';
+import useAuth from '@/hooks/useAuth';
+import { usePutFavoriteTicker } from '@/api/hooks/usePutFavoriteTicker';
+import LoginModal from '@/components/common/Modal/LoginModal';
+import { useLocation } from 'react-router-dom';
 
 export default function TickerItem({ item }: { item: PredictionDataResponse }) {
   const isMobile = useIsMobile();
   const getVariant = useGetVariant(item.sentiment);
   const getSignSymbol = useGetSignSymbol(item.sentiment);
+  const { isAuthenticated } = useAuth();
+  const location = useLocation();
+  const [isFavorite, setIsFavorite] = useState(item.isFavorite ?? false);
+  const [showLoginModal, setShowLoginModal] = useState(false);
+  const { mutate: putFavoriteTicker } = usePutFavoriteTicker();
+
+  const handleLikeClick = useCallback(
+    (event: React.MouseEvent) => {
+      event.stopPropagation();
+      event.preventDefault();
+      if (!isAuthenticated) {
+        setShowLoginModal(true);
+        return;
+      }
+      const nextFavorite = !isFavorite;
+      setIsFavorite(nextFavorite);
+      putFavoriteTicker({
+        tickerCode: item.tickerCode,
+        mode: nextFavorite ? 'on' : 'off',
+      });
+    },
+    [isFavorite, isAuthenticated, item.tickerCode, putFavoriteTicker]
+  );
 
   return (
-    <Wrapper to={`/ticker/${item.tickerId}`}>
-      <LeftSection>
-        <TickerInfo>
-          <Text size={isMobile ? 's' : 'm'} weight="bold">
-            {item.tickerCode}
-          </Text>
-          <Text size={isMobile ? 'xxs' : 'xs'} weight="normal" variant="grey">
-            {item.shortCompanyName}
-          </Text>
-        </TickerInfo>
-        <SignalInfo>
-          {getSignSymbol && (
-            <span
-              style={{
-                marginRight: '4px',
-                fontSize: isMobile ? '12px' : '14px',
-              }}
+    <>
+      <Wrapper to={`/ticker/${item.tickerId}`}>
+        <LeftSection>
+          <TickerInfo>
+            <Text size={isMobile ? 's' : 'm'} weight="bold">
+              {item.tickerCode}
+            </Text>
+            <Text size={isMobile ? 'xxs' : 'xs'} weight="normal" variant="grey">
+              {item.shortCompanyName}
+            </Text>
+            <LikeIconWrapper onClick={handleLikeClick}>
+              {isFavorite ? (
+                <PiHeartFill color="#fe7373" size={isMobile ? 18 : 22} />
+              ) : (
+                <PiHeartLight size={isMobile ? 18 : 22} color="#ccc" />
+              )}
+            </LikeIconWrapper>
+          </TickerInfo>
+          <SignalInfo>
+            {getSignSymbol && (
+              <span
+                style={{
+                  marginRight: '4px',
+                  fontSize: isMobile ? '12px' : '14px',
+                }}
+              >
+                {getSignSymbol}
+              </span>
+            )}
+            <Text
+              size={isMobile ? 'xxs' : 'xs'}
+              weight="bold"
+              variant={getVariant}
             >
-              {getSignSymbol}
-            </span>
-          )}
-          <Text
-            size={isMobile ? 'xxs' : 'xs'}
-            weight="bold"
-            variant={getVariant}
-          >
-            {item.predictionStrategy} 신호
-          </Text>
-        </SignalInfo>
-      </LeftSection>
+              {item.predictionStrategy} 신호
+            </Text>
+          </SignalInfo>
+        </LeftSection>
 
-      <PriceInfo>
-        <GraphView graphData={item.graphData} />
-      </PriceInfo>
-    </Wrapper>
+        <PriceInfo>
+          <GraphView graphData={item.graphData} />
+        </PriceInfo>
+      </Wrapper>
+      {showLoginModal && (
+        <LoginModal
+          immediateOpen={true}
+          currentPath={location.pathname}
+          onClose={() => setShowLoginModal(false)}
+        />
+      )}
+    </>
   );
 }
 
@@ -83,7 +128,7 @@ const LeftSection = styled.div`
 const TickerInfo = styled.div`
   display: flex;
   flex-direction: row;
-  align-items: baseline;
+  align-items: flex-end;
   gap: 8px;
 `;
 
@@ -98,4 +143,11 @@ const PriceInfo = styled.div`
   align-items: flex-end;
   justify-content: center;
   flex: 1;
+`;
+
+const LikeIconWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  line-height: 1;
 `;

--- a/src/mocks/detailHandlers.ts
+++ b/src/mocks/detailHandlers.ts
@@ -48,6 +48,7 @@ const mockTickerDetail = {
     volume: 1539200,
     article: mockNewsData,
   },
+  isFavorite: false,
 };
 
 const generateGraphDataWithChangeRate = (

--- a/src/mocks/newsHandler.ts
+++ b/src/mocks/newsHandler.ts
@@ -6,6 +6,7 @@ import { getFilterTickerListPath } from '@/api/hooks/useGetFilterTickerList';
 const mockNewsList = [
   {
     articleId: '1',
+    isFavorite: true,
     title:
       'Bone Marrow Failure Market Growth Accelerates with Advances in Cell and Gene Therapy | DelveInsight',
     description:
@@ -20,6 +21,7 @@ const mockNewsList = [
   },
   {
     articleId: '29c3fbac-e2e7-41c0-baa3-aad081142d8f',
+    isFavorite: false,
     title: 'Transaction in Own Shares',
     description:
       'Shell plc announced a share buyback program on September 1, 2025, purchasing shares across multiple trading venues including London Stock Exchange, Chi-X, BATS, and Amsterdam exchanges. HSBC Bank plc is executing the trading decisions independently from July 31 to October 24, 2025.',

--- a/src/pages/ArticleDetail/index.tsx
+++ b/src/pages/ArticleDetail/index.tsx
@@ -1,19 +1,44 @@
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import { useState, useCallback } from 'react';
 import { useGetArticleDetail } from '@/api/hooks/useGetArticleDetail';
 import Loading from '@/components/common/Layout/Loading';
 import { Text } from '@/components/common/typography/Text';
 import { Paragraph } from '@/components/common/typography/Paragraph';
 import ArticleTicker from '@/components/ArticleDetail/ArticleTicker';
 import { IoIosArrowBack } from 'react-icons/io';
+import { PiHeartFill, PiHeartLight } from 'react-icons/pi';
 import styled from 'styled-components';
 import useIsMobile from '@/hooks/useIsMobile';
+import useAuth from '@/hooks/useAuth';
+import { usePutFavoriteArticle } from '@/api/hooks/usePutFavoriteArticle';
+import LoginModal from '@/components/common/Modal/LoginModal';
 
 export default function ArticleDetailPage() {
   const { id } = useParams() as { id: string };
   const navigate = useNavigate();
+  const location = useLocation();
   const isMobile = useIsMobile();
+  const { isAuthenticated } = useAuth();
   const { data: articleResponse, isLoading, error } = useGetArticleDetail(id);
   const articleData = articleResponse?.content;
+  const [isFavorite, setIsFavorite] = useState(
+    articleData?.isFavorite ?? false
+  );
+  const [showLoginModal, setShowLoginModal] = useState(false);
+  const { mutate: putFavoriteArticle } = usePutFavoriteArticle();
+
+  const handleLikeClick = useCallback(() => {
+    if (!isAuthenticated) {
+      setShowLoginModal(true);
+      return;
+    }
+    const nextFavorite = !isFavorite;
+    setIsFavorite(nextFavorite);
+    putFavoriteArticle({
+      articleId: id,
+      mode: nextFavorite ? 'on' : 'off',
+    });
+  }, [isFavorite, isAuthenticated, id, putFavoriteArticle]);
 
   if (isLoading) {
     return <Loading />;
@@ -101,6 +126,31 @@ export default function ArticleDetailPage() {
             ))}
           </TickersGrid>
         </TickersSection>
+      )}
+
+      <ScrapButtonWrapper>
+        <ScrapButton onClick={handleLikeClick}>
+          {isFavorite ? (
+            <PiHeartFill color="#fe7373" size={isMobile ? 16 : 18} />
+          ) : (
+            <PiHeartLight size={isMobile ? 16 : 18} color="#2d70d3" />
+          )}
+          <Text
+            size={isMobile ? 'xxs' : 'xs'}
+            weight="normal"
+            variant="#2d70d3"
+          >
+            기사 스크랩
+          </Text>
+        </ScrapButton>
+      </ScrapButtonWrapper>
+
+      {showLoginModal && (
+        <LoginModal
+          immediateOpen={true}
+          currentPath={location.pathname}
+          onClose={() => setShowLoginModal(false)}
+        />
       )}
     </Wrapper>
   );
@@ -219,6 +269,26 @@ const BackButton = styled.button`
   border: none;
   color: #6b7280;
   cursor: pointer;
+`;
+
+const ScrapButtonWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
+const ScrapButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border: 1px solid #2d70d3;
+  border-radius: 8px;
+  background-color: #ffffff;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #f3f5f7;
+  }
 `;
 
 const ErrorMessage = styled.div`

--- a/src/pages/ArticleDetail/index.tsx
+++ b/src/pages/ArticleDetail/index.tsx
@@ -34,10 +34,15 @@ export default function ArticleDetailPage() {
     }
     const nextFavorite = !isFavorite;
     setIsFavorite(nextFavorite);
-    putFavoriteArticle({
-      articleId: id,
-      mode: nextFavorite ? 'on' : 'off',
-    });
+    putFavoriteArticle(
+      { articleId: id, mode: nextFavorite ? 'on' : 'off' },
+      {
+        onError: () => {
+          setIsFavorite(!nextFavorite);
+          alert('스크랩 처리에 실패했습니다. 다시 시도해주세요.');
+        },
+      }
+    );
   }, [isFavorite, isAuthenticated, id, putFavoriteArticle]);
 
   if (isLoading) {

--- a/src/pages/ArticleDetail/index.tsx
+++ b/src/pages/ArticleDetail/index.tsx
@@ -1,5 +1,5 @@
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useGetArticleDetail } from '@/api/hooks/useGetArticleDetail';
 import Loading from '@/components/common/Layout/Loading';
 import { Text } from '@/components/common/typography/Text';
@@ -26,6 +26,12 @@ export default function ArticleDetailPage() {
   );
   const [showLoginModal, setShowLoginModal] = useState(false);
   const { mutate: putFavoriteArticle } = usePutFavoriteArticle();
+
+  useEffect(() => {
+    if (articleData?.isFavorite !== undefined) {
+      setIsFavorite(articleData.isFavorite);
+    }
+  }, [articleData?.isFavorite]);
 
   const handleLikeClick = useCallback(() => {
     if (!isAuthenticated) {

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -5,7 +5,7 @@ import TickerCharts from '@/components/Ticker/TickerCharts';
 import RealTimeTickerCharts from '@/components/Ticker/RealTimeTickerCharts';
 import ScoreGaugeChart from '@/components/Detail/ScoreGaugeChart';
 import Button from '@/components/common/Button';
-import { useParams } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import { useGetTickerDetail } from '@/api/hooks/useGetTickerDetail';
 import { useGetRealGraph, RealGraphPeriod } from '@/api/hooks/useGetRealGraph';
@@ -38,6 +38,7 @@ export default function DetailPage() {
   const [currentNewsIndex, setCurrentNewsIndex] = useState(0);
   const [showSummaryModal, setShowSummaryModal] = useState(false);
   const [showLoginModal, setShowLoginModal] = useState(false);
+  const location = useLocation();
   const scrollPositionRef = useRef(0);
   const queryClient = useQueryClient();
   const isMobile = useIsMobile();

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -12,15 +12,19 @@ import { useGetRealGraph, RealGraphPeriod } from '@/api/hooks/useGetRealGraph';
 import { useGetRealTimePrice } from '@/api/hooks/useGetRealTimePrice';
 import { useGetRealTimeStream } from '@/api/hooks/useGetRealTimeStream';
 import { useGetArticleSummaryTicker } from '@/api/hooks/useGetArticleSummaryTicker';
+import { usePutFavoriteTicker } from '@/api/hooks/usePutFavoriteTicker';
 import Loading from '@/components/common/Layout/Loading';
 import { TickerRealTimeGraphResponse } from '@/types';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { Paragraph } from '@/components/common/typography/Paragraph';
 import RotationArticleItem from '@/components/Detail/RotationArticleItem';
 import SummaryModal from '@/components/Detail/SummaryModal';
 import useIsMobile from '@/hooks/useIsMobile';
+import useAuth from '@/hooks/useAuth';
 import { MdOutlineStickyNote2 } from 'react-icons/md';
+import { PiHeartFill, PiHeartLight } from 'react-icons/pi';
+import LoginModal from '@/components/common/Modal/LoginModal';
 
 export default function DetailPage() {
   const { id } = useParams() as { id: string };
@@ -33,9 +37,11 @@ export default function DetailPage() {
   const [showRefreshTooltip, setShowRefreshTooltip] = useState(false);
   const [currentNewsIndex, setCurrentNewsIndex] = useState(0);
   const [showSummaryModal, setShowSummaryModal] = useState(false);
+  const [showLoginModal, setShowLoginModal] = useState(false);
   const scrollPositionRef = useRef(0);
   const queryClient = useQueryClient();
   const isMobile = useIsMobile();
+  const { isAuthenticated } = useAuth();
 
   const {
     data: tickerResponse,
@@ -58,11 +64,37 @@ export default function DetailPage() {
     tickerId: id,
   });
   const { data: summaryResponse } = useGetArticleSummaryTicker(id);
+  const { mutate: putFavoriteTicker } = usePutFavoriteTicker();
 
   const tickerData = tickerResponse?.content;
   const realGraphData = realGraphResponse?.content;
   const realTimePriceData = realTimePriceResponse?.content;
   const summaryData = summaryResponse?.content ?? null;
+  const [isFavorite, setIsFavorite] = useState(false);
+
+  useEffect(() => {
+    if (tickerData?.isFavorite !== undefined) {
+      setIsFavorite(tickerData.isFavorite);
+    }
+  }, [tickerData?.isFavorite]);
+
+  const handleLikeClick = useCallback(
+    (event: React.MouseEvent) => {
+      event.stopPropagation();
+      event.preventDefault();
+      if (!isAuthenticated) {
+        setShowLoginModal(true);
+        return;
+      }
+      const nextFavorite = !isFavorite;
+      setIsFavorite(nextFavorite);
+      putFavoriteTicker({
+        tickerCode: tickerData?.tickerCode ?? '',
+        mode: nextFavorite ? 'on' : 'off',
+      });
+    },
+    [isFavorite, isAuthenticated, tickerData?.tickerCode, putFavoriteTicker]
+  );
 
   useEffect(() => {
     if (realTimePriceData?.priceDataList) {
@@ -164,22 +196,134 @@ export default function DetailPage() {
   }
 
   return (
-    <Wrapper>
-      <SummaryModal
-        isOpen={showSummaryModal}
-        onClose={() => setShowSummaryModal(false)}
-        summaryData={summaryData}
-      />
-      <TickerTitle>
-        <CompanyInfo>
-          <Text size={isMobile ? 'm' : 'l'} weight="bold">
-            {tickerData.shortCompanyName}
-          </Text>
-          <Text size={isMobile ? 'xs' : 's'} weight="normal" variant="grey">
-            {tickerData.tickerCode}
-          </Text>
-        </CompanyInfo>
-        {!isMobile && (
+    <>
+      <Wrapper>
+        <SummaryModal
+          isOpen={showSummaryModal}
+          onClose={() => setShowSummaryModal(false)}
+          summaryData={summaryData}
+        />
+        <TickerTitle>
+          <CompanyInfo>
+            <Text size={isMobile ? 'm' : 'l'} weight="bold">
+              {tickerData.shortCompanyName}
+            </Text>
+            <Text size={isMobile ? 'xs' : 's'} weight="normal" variant="grey">
+              {tickerData.tickerCode}
+            </Text>
+            <LikeIconWrapper onClick={handleLikeClick}>
+              {isFavorite ? (
+                <PiHeartFill color="#fe7373" size={isMobile ? 18 : 22} />
+              ) : (
+                <PiHeartLight size={isMobile ? 18 : 22} color="#ccc" />
+              )}
+            </LikeIconWrapper>
+          </CompanyInfo>
+          {!isMobile && (
+            <ScoreTitleContainer>
+              <Paragraph size={isMobile ? 'xs' : 's'} weight="bold">
+                종목 점수
+              </Paragraph>
+              <TooltipContainer
+                onMouseEnter={() => setShowTooltip(true)}
+                onMouseLeave={() => setShowTooltip(false)}
+              >
+                <BsFillQuestionCircleFill
+                  size={isMobile ? 14 : 16}
+                  color="#BCC7D9"
+                />
+                {showTooltip && (
+                  <Tooltip>
+                    수집된 기사의 감정(긍정/부정) 비율에 추세를 반영하여 계산된
+                    점수입니다.
+                  </Tooltip>
+                )}
+              </TooltipContainer>
+            </ScoreTitleContainer>
+          )}
+        </TickerTitle>
+        <TickerInfo>
+          <InfoGrid>
+            <InfoItem>
+              <Text size={isMobile ? 'xxs' : 'xs'} weight="normal">
+                시가
+              </Text>
+              <Text
+                size={isMobile ? 'xxs' : 'xs'}
+                weight="normal"
+                variant="grey"
+              >
+                $ {tickerData.detailData.open}
+              </Text>
+            </InfoItem>
+
+            <InfoItem>
+              <Text size={isMobile ? 'xxs' : 'xs'} weight="normal">
+                종가
+              </Text>
+              <Text
+                size={isMobile ? 'xxs' : 'xs'}
+                weight="normal"
+                variant="grey"
+              >
+                $ {tickerData.detailData.close}
+              </Text>
+            </InfoItem>
+
+            <InfoItem>
+              <Text size={isMobile ? 'xxs' : 'xs'} weight="normal">
+                고가
+              </Text>
+              <Text
+                size={isMobile ? 'xxs' : 'xs'}
+                weight="normal"
+                variant="grey"
+              >
+                $ {tickerData.detailData.high}
+              </Text>
+            </InfoItem>
+
+            <InfoItem>
+              <Text size={isMobile ? 'xxs' : 'xs'} weight="normal">
+                저가
+              </Text>
+              <Text
+                size={isMobile ? 'xxs' : 'xs'}
+                weight="normal"
+                variant="grey"
+              >
+                $ {tickerData.detailData.low}
+              </Text>
+            </InfoItem>
+
+            <InfoItem>
+              <Text size={isMobile ? 'xxs' : 'xs'} weight="normal">
+                거래량
+              </Text>
+              <Text
+                size={isMobile ? 'xxs' : 'xs'}
+                weight="normal"
+                variant="grey"
+              >
+                {tickerData.detailData.volume.toLocaleString()}주
+              </Text>
+            </InfoItem>
+            <ItemDate>
+              <Text size="xxs" weight="normal" variant="grey">
+                * {formatDate(tickerData.detailData.priceDate)} 기준
+              </Text>
+            </ItemDate>
+          </InfoGrid>
+          {!isMobile && (
+            <ScoreGaugeChart
+              value={tickerData.sentimentScore}
+              maxValue={100}
+              title="점수"
+              predictionStrategy={tickerData.predictionStrategy}
+            />
+          )}
+        </TickerInfo>
+        {isMobile && (
           <ScoreTitleContainer>
             <Paragraph size={isMobile ? 'xs' : 's'} weight="bold">
               종목 점수
@@ -194,67 +338,14 @@ export default function DetailPage() {
               />
               {showTooltip && (
                 <Tooltip>
-                  수집된 기사의 감정(긍정/부정) 비율에 추세를 반영하여 계산된
-                  점수입니다.
+                  수집된 기사의 감정(긍정/부정) 비율에
+                  <br /> 추세를 반영하여 계산된 점수입니다.
                 </Tooltip>
               )}
             </TooltipContainer>
           </ScoreTitleContainer>
         )}
-      </TickerTitle>
-      <TickerInfo>
-        <InfoGrid>
-          <InfoItem>
-            <Text size={isMobile ? 'xxs' : 'xs'} weight="normal">
-              시가
-            </Text>
-            <Text size={isMobile ? 'xxs' : 'xs'} weight="normal" variant="grey">
-              $ {tickerData.detailData.open}
-            </Text>
-          </InfoItem>
-
-          <InfoItem>
-            <Text size={isMobile ? 'xxs' : 'xs'} weight="normal">
-              종가
-            </Text>
-            <Text size={isMobile ? 'xxs' : 'xs'} weight="normal" variant="grey">
-              $ {tickerData.detailData.close}
-            </Text>
-          </InfoItem>
-
-          <InfoItem>
-            <Text size={isMobile ? 'xxs' : 'xs'} weight="normal">
-              고가
-            </Text>
-            <Text size={isMobile ? 'xxs' : 'xs'} weight="normal" variant="grey">
-              $ {tickerData.detailData.high}
-            </Text>
-          </InfoItem>
-
-          <InfoItem>
-            <Text size={isMobile ? 'xxs' : 'xs'} weight="normal">
-              저가
-            </Text>
-            <Text size={isMobile ? 'xxs' : 'xs'} weight="normal" variant="grey">
-              $ {tickerData.detailData.low}
-            </Text>
-          </InfoItem>
-
-          <InfoItem>
-            <Text size={isMobile ? 'xxs' : 'xs'} weight="normal">
-              거래량
-            </Text>
-            <Text size={isMobile ? 'xxs' : 'xs'} weight="normal" variant="grey">
-              {tickerData.detailData.volume.toLocaleString()}주
-            </Text>
-          </InfoItem>
-          <ItemDate>
-            <Text size="xxs" weight="normal" variant="grey">
-              * {formatDate(tickerData.detailData.priceDate)} 기준
-            </Text>
-          </ItemDate>
-        </InfoGrid>
-        {!isMobile && (
+        {isMobile && (
           <ScoreGaugeChart
             value={tickerData.sentimentScore}
             maxValue={100}
@@ -262,69 +353,11 @@ export default function DetailPage() {
             predictionStrategy={tickerData.predictionStrategy}
           />
         )}
-      </TickerInfo>
-      {isMobile && (
-        <ScoreTitleContainer>
+        <StockPriceSection>
           <Paragraph size={isMobile ? 'xs' : 's'} weight="bold">
-            종목 점수
+            실제 주가
           </Paragraph>
-          <TooltipContainer
-            onMouseEnter={() => setShowTooltip(true)}
-            onMouseLeave={() => setShowTooltip(false)}
-          >
-            <BsFillQuestionCircleFill
-              size={isMobile ? 14 : 16}
-              color="#BCC7D9"
-            />
-            {showTooltip && (
-              <Tooltip>
-                수집된 기사의 감정(긍정/부정) 비율에
-                <br /> 추세를 반영하여 계산된 점수입니다.
-              </Tooltip>
-            )}
-          </TooltipContainer>
-        </ScoreTitleContainer>
-      )}
-      {isMobile && (
-        <ScoreGaugeChart
-          value={tickerData.sentimentScore}
-          maxValue={100}
-          title="점수"
-          predictionStrategy={tickerData.predictionStrategy}
-        />
-      )}
-      <StockPriceSection>
-        <Paragraph size={isMobile ? 'xs' : 's'} weight="bold">
-          실제 주가
-        </Paragraph>
-        {isMobile && (
-          <SummaryButton
-            onClick={() => setShowSummaryModal(true)}
-            variant="grey"
-            size="small"
-          >
-            <MdOutlineStickyNote2 size={16} />
-          </SummaryButton>
-        )}
-      </StockPriceSection>
-      <PeriodSelectorContainer>
-        <PeriodSelector>
-          {(['2W', '1M', '6M', '1Y'] as RealGraphPeriod[]).map((p) => (
-            <PeriodButton
-              key={p}
-              $active={period === p && !isLiveMode}
-              onClick={() => handlePeriodChange(p)}
-            >
-              {p}
-            </PeriodButton>
-          ))}
-          <LiveButton $active={isLiveMode} onClick={handleLiveMode}>
-            live
-            <LiveDot />
-          </LiveButton>
-        </PeriodSelector>
-        <ButtonGroup>
-          {!isMobile && (
+          {isMobile && (
             <SummaryButton
               onClick={() => setShowSummaryModal(true)}
               variant="grey"
@@ -333,40 +366,81 @@ export default function DetailPage() {
               <MdOutlineStickyNote2 size={16} />
             </SummaryButton>
           )}
-          <RefreshContainer>
-            <RefreshButton onClick={handleRefresh} variant="grey" size="small">
-              <IoMdRefresh size={isMobile ? 14 : 16} />
-            </RefreshButton>
-            {showRefreshTooltip && (
-              <RefreshTooltip>최신 상태로 업데이트 되었습니다!</RefreshTooltip>
+        </StockPriceSection>
+        <PeriodSelectorContainer>
+          <PeriodSelector>
+            {(['2W', '1M', '6M', '1Y'] as RealGraphPeriod[]).map((p) => (
+              <PeriodButton
+                key={p}
+                $active={period === p && !isLiveMode}
+                onClick={() => handlePeriodChange(p)}
+              >
+                {p}
+              </PeriodButton>
+            ))}
+            <LiveButton $active={isLiveMode} onClick={handleLiveMode}>
+              live
+              <LiveDot />
+            </LiveButton>
+          </PeriodSelector>
+          <ButtonGroup>
+            {!isMobile && (
+              <SummaryButton
+                onClick={() => setShowSummaryModal(true)}
+                variant="grey"
+                size="small"
+              >
+                <MdOutlineStickyNote2 size={16} />
+              </SummaryButton>
             )}
-          </RefreshContainer>
-        </ButtonGroup>
-      </PeriodSelectorContainer>
-      {isLiveMode ? (
-        <RealTimeTickerCharts realTimeData={liveChartData} />
-      ) : (
-        realGraphData && (
-          <TickerCharts
-            realData={realGraphData.graphData || []}
-            sentiment={tickerData.sentiment ?? 0}
-          />
-        )
-      )}
-      {tickerData?.detailData.article &&
-        tickerData.detailData.article.length > 0 && (
-          <>
-            <Paragraph size={isMobile ? 'xs' : 's'} weight="bold">
-              실시간 기사
-            </Paragraph>
-            <RotationArticleItem
-              key={currentNewsIndex}
-              item={tickerData.detailData.article[currentNewsIndex]}
-              tickerCode={tickerData.tickerCode}
+            <RefreshContainer>
+              <RefreshButton
+                onClick={handleRefresh}
+                variant="grey"
+                size="small"
+              >
+                <IoMdRefresh size={isMobile ? 14 : 16} />
+              </RefreshButton>
+              {showRefreshTooltip && (
+                <RefreshTooltip>
+                  최신 상태로 업데이트 되었습니다!
+                </RefreshTooltip>
+              )}
+            </RefreshContainer>
+          </ButtonGroup>
+        </PeriodSelectorContainer>
+        {isLiveMode ? (
+          <RealTimeTickerCharts realTimeData={liveChartData} />
+        ) : (
+          realGraphData && (
+            <TickerCharts
+              realData={realGraphData.graphData || []}
+              sentiment={tickerData.sentiment ?? 0}
             />
-          </>
+          )
         )}
-    </Wrapper>
+        {tickerData?.detailData.article &&
+          tickerData.detailData.article.length > 0 && (
+            <>
+              <Paragraph size={isMobile ? 'xs' : 's'} weight="bold">
+                실시간 기사
+              </Paragraph>
+              <RotationArticleItem
+                key={currentNewsIndex}
+                item={tickerData.detailData.article[currentNewsIndex]}
+                tickerCode={tickerData.tickerCode}
+              />
+            </>
+          )}
+      </Wrapper>
+      {showLoginModal && (
+        <LoginModal
+          immediateOpen={true}
+          currentPath={location.pathname}
+          onClose={() => setShowLoginModal(false)}
+        />
+      )}
+    </>
   );
 }
 const Wrapper = styled.div`
@@ -728,4 +802,11 @@ const ErrorMessage = styled.div`
   padding: 20px;
   text-align: center;
   color: #e74c3c;
+`;
+
+const LikeIconWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  line-height: 1;
 `;

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -88,10 +88,18 @@ export default function DetailPage() {
       }
       const nextFavorite = !isFavorite;
       setIsFavorite(nextFavorite);
-      putFavoriteTicker({
-        tickerCode: tickerData?.tickerCode ?? '',
-        mode: nextFavorite ? 'on' : 'off',
-      });
+      putFavoriteTicker(
+        {
+          tickerCode: tickerData?.tickerCode ?? '',
+          mode: nextFavorite ? 'on' : 'off',
+        },
+        {
+          onError: () => {
+            setIsFavorite(!nextFavorite);
+            alert('좋아요 처리에 실패했습니다. 다시 시도해주세요.');
+          },
+        }
+      );
     },
     [isFavorite, isAuthenticated, tickerData?.tickerCode, putFavoriteTicker]
   );

--- a/src/pages/My/index.tsx
+++ b/src/pages/My/index.tsx
@@ -163,7 +163,7 @@ export default function MyPage() {
         <FavoriteArticleSection />
       </FavoriteSection>
       <Text
-        size={isMobile ? 'xxs' : 'xs'}
+        size={isMobile ? '12px' : 'xxs'}
         weight="normal"
         style={{ color: '#9e9e9e', width: '90%' }}
       >
@@ -290,7 +290,7 @@ const FavoriteSection = styled.div`
   display: flex;
   flex-direction: column;
   gap: 40px;
-  margin-bottom: 20px;
+  margin-bottom: 40px;
 
   @media screen and (max-width: 768px) {
     width: 90%;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -89,8 +89,6 @@ export type ArticleDataResponse = {
   publishedDate: string;
   source: string;
   isFavorite?: boolean;
-  // sentiment: string;
-  // reasoning: string;
 };
 
 export type ArticleListData = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -53,6 +53,7 @@ export type TickerDetailData = {
   articleCount: number;
   sentimentScore: number;
   detailData: DetailDataResponse;
+  isFavorite?: boolean;
 };
 
 export type TickerGraphDataResponse = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -155,6 +155,7 @@ export type ArticleDetailResponse = {
   publishedDate: string;
   source: string;
   tickers: ArticleDetailTickerResponse[];
+  isFavorite?: boolean;
 };
 
 export type ExchangeRateResponse = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,6 +26,7 @@ export type PredictionDataResponse = {
   negativeKeywords?: string;
   articleTitles?: ArticleTitleResponse[]; // Optional: param=article
   graphData?: PredictionListGraphDataResponse; // Optional: param=graph
+  isFavorite?: boolean;
 };
 
 export type TickerListData = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -88,6 +88,7 @@ export type ArticleDataResponse = {
   contentUrl: string;
   publishedDate: string;
   source: string;
+  isFavorite?: boolean;
   // sentiment: string;
   // reasoning: string;
 };


### PR DESCRIPTION
- [x] feat: tickerItem에 종목 좋아요 기능 추가
- [x] feat: tickerDetail 페이지에 종목 좋아요 기능 추가
- [x] feat: articleItem에 기사 좋아요 기능 추가
- [x] chore: articleItem 관련 필요없는 코드 제거
- [x] feat: articleDetail 페이지에 기사 좋아요 기능 추가
- [x] design: mypage 회원 탈퇴 메시지 font-size 축소
- [x] 좋아요/스크랩 api 호출 실패 시 낙관적 업데이트 상태 복구 및 alert 표시 추가
- [x] ArticleDetail 데이터의 isFavorite 상태를 api 응답과 동기화하는 useEffect 추가
- [x] CompanyTag key에 중복된 회사명이 있을 경우 key 충돌 방지 위해 인덱스 포함 키로 변경
- [x] LoginModal 사용하기 위해 필요한 useLocation 추가