### PR TITLE
[Articker - 29] 불필요한 리프레시 토큰 갱신 요청 제거 및 인터셉터 기반 갱신으로 로직 변경

### DIFF
--- a/src/api/instance/index.ts
+++ b/src/api/instance/index.ts
@@ -2,14 +2,25 @@ import { QueryClient } from '@tanstack/react-query';
 import type { AxiosInstance, AxiosRequestConfig } from 'axios';
 import axios from 'axios';
 import getCurrentConfig from '../config';
+import { postReissueTokenPath } from '@/api/hooks/usePostReissueToken';
 
 let accessToken: string | null = null;
+let onUnauthorized: (() => void) | null = null;
+let refreshTokenFn: (() => Promise<string>) | null = null;
 
 export const setAccessToken = (token: string | null) => {
   accessToken = token;
 };
 
 export const getAccessToken = () => accessToken;
+
+export const setOnUnauthorized = (callback: () => void) => {
+  onUnauthorized = callback;
+};
+
+export const setRefreshTokenFn = (fn: () => Promise<string>) => {
+  refreshTokenFn = fn;
+};
 
 const initInstance = (config: AxiosRequestConfig): AxiosInstance => {
   const instance = axios.create({
@@ -29,22 +40,44 @@ const initInstance = (config: AxiosRequestConfig): AxiosInstance => {
       }
       return requestConfig;
     },
-    (error) => {
-      return Promise.reject(error);
-    }
+    (error) => Promise.reject(error)
   );
 
   instance.interceptors.response.use(
     (response) => response,
-    (error) => {
+    async (error) => {
+      const originalRequest = error.config;
+
       if (process.env.NODE_ENV === 'development') {
         console.error('API Error:', {
-          url: error.config?.url,
-          method: error.config?.method?.toUpperCase(),
+          url: originalRequest?.url,
+          method: originalRequest?.method?.toUpperCase(),
           status: error.response?.status,
           message: error.message,
           data: error.response?.data,
         });
+      }
+      const isUnauthorized = error.response?.status === 401;
+      const isReissueRequest = originalRequest?.url?.includes(
+        postReissueTokenPath()
+      );
+      const isAlreadyRetried = originalRequest?._retry;
+
+      if (
+        isUnauthorized &&
+        !isReissueRequest &&
+        !isAlreadyRetried &&
+        refreshTokenFn
+      ) {
+        originalRequest._retry = true;
+        try {
+          const newToken = await refreshTokenFn();
+          originalRequest.headers.Authorization = `Bearer ${newToken}`;
+          return instance(originalRequest);
+        } catch {
+          setAccessToken(null);
+          onUnauthorized?.();
+        }
       }
       return Promise.reject(error);
     }

--- a/src/api/instance/index.ts
+++ b/src/api/instance/index.ts
@@ -7,6 +7,8 @@ import { postReissueTokenPath } from '@/api/hooks/usePostReissueToken';
 let accessToken: string | null = null;
 let onUnauthorized: (() => void) | null = null;
 let refreshTokenFn: (() => Promise<string>) | null = null;
+let refreshInFlight: Promise<string> | null = null;
+let isLoggingOut = false;
 
 export const setAccessToken = (token: string | null) => {
   accessToken = token;
@@ -71,12 +73,18 @@ const initInstance = (config: AxiosRequestConfig): AxiosInstance => {
       ) {
         originalRequest._retry = true;
         try {
-          const newToken = await refreshTokenFn();
+          refreshInFlight ??= refreshTokenFn().finally(() => {
+            refreshInFlight = null;
+          });
+          const newToken = await refreshInFlight;
           originalRequest.headers.Authorization = `Bearer ${newToken}`;
           return instance(originalRequest);
         } catch {
-          setAccessToken(null);
-          onUnauthorized?.();
+          if (!isLoggingOut) {
+            isLoggingOut = true;
+            setAccessToken(null);
+            onUnauthorized?.();
+          }
         }
       }
       return Promise.reject(error);

--- a/src/provider/Auth/index.tsx
+++ b/src/provider/Auth/index.tsx
@@ -3,13 +3,15 @@ import { usePostReissueToken } from '@/api/hooks/usePostReissueToken';
 import { usePostLogout } from '@/api/hooks/usePostLogout';
 import { AuthContext } from './AuthContext';
 import { UserInfoResponse } from '@/types';
-import { setAccessToken } from '@/api/instance';
+import {
+  setAccessToken,
+  setOnUnauthorized,
+  setRefreshTokenFn,
+} from '@/api/instance';
 
 interface AuthProviderProps {
   children: React.ReactNode;
 }
-
-const ACCESS_TOKEN_REFRESH_INTERVAL = 60 * 60 * 1000; // 만료 시간 1시간
 
 export default function AuthProvider({ children }: AuthProviderProps) {
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(
@@ -31,15 +33,17 @@ export default function AuthProvider({ children }: AuthProviderProps) {
     window.location.href = '/';
   }, [logout]);
 
-  const refreshTokenRegularly = useCallback(async () => {
-    try {
-      const tokenResponse = await refreshToken({ deviceType: 'web' });
-      setAccessToken(tokenResponse.content.accessToken);
-    } catch (error) {
-      console.error('Token refresh failed:', error);
-      handleLogout();
-    }
-  }, [refreshToken, handleLogout]);
+  const doRefreshToken = useCallback(async () => {
+    const tokenResponse = await refreshToken({ deviceType: 'web' });
+    const newToken = tokenResponse.content.accessToken;
+    setAccessToken(newToken);
+    return newToken;
+  }, [refreshToken]);
+
+  useEffect(() => {
+    setRefreshTokenFn(doRefreshToken);
+    setOnUnauthorized(handleLogout);
+  }, [doRefreshToken, handleLogout]);
 
   const handleLoginSuccess = useCallback(
     async (userInfo: UserInfoResponse) => {
@@ -58,7 +62,7 @@ export default function AuthProvider({ children }: AuthProviderProps) {
         localStorage.getItem('isAuthenticated') === 'true';
       if (savedAuthStatus) {
         try {
-          await refreshTokenRegularly();
+          await doRefreshToken();
         } catch (error) {
           console.error(
             'Failed to refresh token during initialization:',
@@ -71,23 +75,7 @@ export default function AuthProvider({ children }: AuthProviderProps) {
     };
 
     initialize();
-  }, [refreshTokenRegularly, handleLogout]);
-
-  useEffect(() => {
-    let intervalId: NodeJS.Timeout;
-
-    if (isAuthenticated) {
-      intervalId = setInterval(() => {
-        refreshTokenRegularly();
-      }, ACCESS_TOKEN_REFRESH_INTERVAL);
-    }
-
-    return () => {
-      if (intervalId) {
-        clearInterval(intervalId);
-      }
-    };
-  }, [isAuthenticated, refreshTokenRegularly]);
+  }, [doRefreshToken, handleLogout]);
 
   const value = useMemo(
     () =>


### PR DESCRIPTION
### ✨ 작업 내용
- [x] 주기적 토큰 갱신(`setInterval`) 방식 제거
- [x] 401 응답 시 토큰 자동 갱신 후 원래 요청 재시도하는 인터셉터 구현
- [x] 토큰 갱신 함수와 로그아웃 콜백을 `AuthProvider`에서 **axios instance로 주입**하는 구조 적용
- 코드 리뷰 반영
  - [x] 여러 요청이 동시 401 응답 시 토큰 갱신 중복 호출 및 로그아웃 중복 실행 방지

---

### ✨ 참고 사항
- axios instance는 React 모듈이 아니므로 훅을 직접 사용할 수 없어, AuthProvider에서 함수를 주입하는 **의존성 주입 방식**을 사용했습니다.
- 토큰 갱신 실패 시 accessToken을 null로 초기화하고 로그아웃 처리합니다.
- 동일 요청의 무한 재시도를 방지하기 위해 `_retry` 플래그를 활용했습니다.
- 동시 401 발생 시 `refreshInFlight`로 갱신 Promise를 공유해 갱신 API는 1회만 호출하고, `isLoggingOut`으로 로그아웃 중복 실행을 방지합니다.

---

### ⏰ 현재 버그

---

### ✏ Git Close
