### PR TITLE
[Articker - 30] 마이페이지 기사 스크랩(좋아요) 버튼 중복 렌더링 제거

### DIFF
--- a/src/components/Article/ArticleItem.tsx
+++ b/src/components/Article/ArticleItem.tsx
@@ -10,7 +10,13 @@ import useAuth from '@/hooks/useAuth';
 import { usePutFavoriteArticle } from '@/api/hooks/usePutFavoriteArticle';
 import LoginModal from '@/components/common/Modal/LoginModal';
 
-export default function NewsItem({ item }: { item: ArticleDataResponse }) {
+export default function NewsItem({
+  item,
+  onToggleLike,
+}: {
+  item: ArticleDataResponse;
+  onToggleLike?: (articleId: string) => void;
+}) {
   const isMobile = useIsMobile();
   const navigate = useNavigate();
   const location = useLocation();
@@ -26,6 +32,10 @@ export default function NewsItem({ item }: { item: ArticleDataResponse }) {
   const handleLikeClick = useCallback(
     (event: React.MouseEvent) => {
       event.stopPropagation();
+      if (onToggleLike) {
+        onToggleLike(item.articleId);
+        return;
+      }
       if (!isAuthenticated) {
         setShowLoginModal(true);
         return;
@@ -42,7 +52,13 @@ export default function NewsItem({ item }: { item: ArticleDataResponse }) {
         }
       );
     },
-    [isFavorite, isAuthenticated, item.articleId, putFavoriteArticle]
+    [
+      isFavorite,
+      isAuthenticated,
+      item.articleId,
+      putFavoriteArticle,
+      onToggleLike,
+    ]
   );
 
   return (

--- a/src/components/My/FavoriteArticleSection.tsx
+++ b/src/components/My/FavoriteArticleSection.tsx
@@ -5,7 +5,6 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useGetFavoriteArticles } from '@/api/hooks/useGetFavoriteArticles';
 import { usePutFavoriteArticle } from '@/api/hooks/usePutFavoriteArticle';
 import { GrPrevious, GrNext } from 'react-icons/gr';
-import { PiHeartFill } from 'react-icons/pi';
 import NoItem from '@/components/common/Layout/NoItem';
 import NewsItem from '@/components/Article/ArticleItem';
 import { Text } from '@/components/common/typography/Text';
@@ -96,18 +95,11 @@ export default function FavoriteArticleSection() {
       ) : (
         <SlideWrapper key={currentPage} $direction={slideDirection}>
           {currentArticles.map((article) => (
-            <ArticleWrapper key={article.articleId}>
-              <NewsItem item={article} />
-              <LikeButton
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleToggleLike(article.articleId);
-                }}
-                aria-label="스크랩 해제"
-              >
-                <PiHeartFill color="#fe7373" size={24} />
-              </LikeButton>
-            </ArticleWrapper>
+            <NewsItem
+              key={article.articleId}
+              item={article}
+              onToggleLike={handleToggleLike}
+            />
           ))}
         </SlideWrapper>
       )}
@@ -193,26 +185,5 @@ const SlideWrapper = styled.div<{ $direction: 'left' | 'right' }>`
       transform: translateX(0);
       opacity: 1;
     }
-  }
-`;
-
-const ArticleWrapper = styled.div`
-  position: relative;
-`;
-
-const LikeButton = styled.button`
-  position: absolute;
-  top: 12px;
-  right: 12px;
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 4px;
-  z-index: 1;
-  display: flex;
-  align-items: center;
-
-  &:hover {
-    opacity: 0.8;
   }
 `;


### PR DESCRIPTION
### ✨ 작업 내용
- [x] `FavoriteArticleSection`에서 스크랩 버튼 중복 렌더링 제거
- [x] `ArticleItem`에 `onToggleLike` optional prop 추가 — 외부 주입 시 내부 mutation 대신 콜백 호출

---

### ✨ 참고 사항
기존 `FavoriteArticleSection`은 `NewsItem`(내부 하트 포함)과 별도 `LikeButton`을 겹쳐 렌더링해 하트가 두 개 보이는 문제가 있었음
-> `ArticleItem`에 `onToggleLike` prop을 추가해 외부에서 post-mutation 로직(캐시 무효화, 페이지 조정)을 주입할 수 있도록 변경
prop이 없는 경우(`ArticleList` 등)는 기존 내부 mutation 방식 유지

---

### ⏰ 현재 버그

---

### ✏ Git Close
