### PR TITLE
[Articker - 33] 통합 검색 결과 페이지 구현

### DIFF
--- a/src/api/hooks/useGetArticleSearchList.ts
+++ b/src/api/hooks/useGetArticleSearchList.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchInstance } from '../instance';
+import { ApiResponse, ArticleSearchListResponse } from '@/types';
+
+export const getArticleSearchListPath = (keyword: string) =>
+  `/api/v1/search/article?keyword=${encodeURIComponent(keyword)}`;
+
+export const getArticleSearchList = async (keyword: string) => {
+  const response = await fetchInstance.get<
+    ApiResponse<ArticleSearchListResponse>
+  >(getArticleSearchListPath(keyword));
+  return response.data;
+};
+
+export const useGetArticleSearchList = (keyword: string) => {
+  const trimmedKeyword = keyword.trim();
+
+  return useQuery({
+    queryKey: ['articleSearchList', trimmedKeyword],
+    queryFn: () => getArticleSearchList(trimmedKeyword),
+    enabled: trimmedKeyword.length >= 2,
+    staleTime: 1000 * 60 * 5,
+  });
+};

--- a/src/api/hooks/useGetTickerSearchList.ts
+++ b/src/api/hooks/useGetTickerSearchList.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchInstance } from '../instance';
+import { ApiResponse, TickerSearchListResponse } from '@/types';
+
+export const getTickerSearchListPath = (keyword: string) =>
+  `/api/v1/search/ticker?keyword=${encodeURIComponent(keyword)}`;
+
+export const getTickerSearchList = async (keyword: string) => {
+  const response = await fetchInstance.get<
+    ApiResponse<TickerSearchListResponse>
+  >(getTickerSearchListPath(keyword));
+  return response.data;
+};
+
+export const useGetTickerSearchList = (keyword: string) => {
+  const trimmedKeyword = keyword.trim();
+
+  return useQuery({
+    queryKey: ['tickerSearchList', trimmedKeyword],
+    queryFn: () => getTickerSearchList(trimmedKeyword),
+    enabled: trimmedKeyword.length >= 2,
+    staleTime: 1000 * 60 * 5,
+  });
+};

--- a/src/components/Search/SearchArticleSection.tsx
+++ b/src/components/Search/SearchArticleSection.tsx
@@ -19,7 +19,7 @@ export default function SearchArticleSection({
   const isMobile = useIsMobile();
   const navigate = useNavigate();
 
-  const { data: searchData } = useGetArticleSearchList(keyword);
+  const { data: searchData, isLoading } = useGetArticleSearchList(keyword);
   const allArticles = searchData?.content.articles ?? [];
   const articles = allArticles.slice(0, ARTICLE_LIMIT);
   const hasMore = allArticles.length > ARTICLE_LIMIT;
@@ -39,7 +39,10 @@ export default function SearchArticleSection({
         )}
       </SectionHeader>
       {articles.length === 0 ? (
-        <NoItem message="관련 기사가 없어요!" height={200} />
+        <NoItem
+          message={isLoading ? '검색 중...' : '관련 기사가 없어요!'}
+          height={200}
+        />
       ) : (
         <ArticleList>
           {articles.map((article) => (

--- a/src/components/Search/SearchArticleSection.tsx
+++ b/src/components/Search/SearchArticleSection.tsx
@@ -1,0 +1,92 @@
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+import { IoIosArrowForward } from 'react-icons/io';
+import { Text } from '@/components/common/typography/Text';
+import { useGetArticleSearchList } from '@/api/hooks/useGetArticleSearchList';
+import useIsMobile from '@/hooks/useIsMobile';
+import NoItem from '@/components/common/Layout/NoItem';
+import NewsItem from '@/components/Article/ArticleItem';
+
+const ARTICLE_LIMIT = 3;
+
+type SearchArticleSectionProps = {
+  keyword: string;
+};
+
+export default function SearchArticleSection({
+  keyword,
+}: SearchArticleSectionProps) {
+  const isMobile = useIsMobile();
+  const navigate = useNavigate();
+
+  const { data: searchData } = useGetArticleSearchList(keyword);
+  const allArticles = searchData?.content.articles ?? [];
+  const articles = allArticles.slice(0, ARTICLE_LIMIT);
+  const hasMore = allArticles.length > ARTICLE_LIMIT;
+
+  return (
+    <SectionContainer>
+      <SectionHeader>
+        <Text size={isMobile ? 's' : 'm'} weight="bold">
+          관련 기사
+        </Text>
+        {hasMore && (
+          // 추후 필터링 된 뉴스 페이지로 수정 필요
+          <MoreBtn onClick={() => navigate('/news')}>
+            더 보기
+            <IoIosArrowForward />
+          </MoreBtn>
+        )}
+      </SectionHeader>
+      {articles.length === 0 ? (
+        <NoItem message="관련 기사가 없어요!" height={200} />
+      ) : (
+        <ArticleList>
+          {articles.map((article) => (
+            <NewsItem key={article.articleId} item={article} />
+          ))}
+        </ArticleList>
+      )}
+    </SectionContainer>
+  );
+}
+
+const SectionContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+`;
+
+const SectionHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const MoreBtn = styled.button`
+  border: none;
+  background: none;
+  border-radius: 10px;
+  padding: 8px 10px;
+  color: black;
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  @media screen and (max-width: 768px) {
+    padding: 6px 8px;
+    font-size: 12px;
+  }
+`;
+
+const ArticleList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;

--- a/src/components/Search/SearchTickerSection.tsx
+++ b/src/components/Search/SearchTickerSection.tsx
@@ -33,7 +33,7 @@ export default function SearchTickerSection({
   const queryClient = useQueryClient();
   const displayCount = isMobile ? 2 : 3;
 
-  const { data: searchData } = useGetTickerSearchList(keyword);
+  const { data: searchData, isLoading } = useGetTickerSearchList(keyword);
   const { mutate: putFavoriteTicker } = usePutFavoriteTicker();
   const tickers = searchData?.content.tickers ?? [];
 
@@ -104,7 +104,10 @@ export default function SearchTickerSection({
         </Text>
       </SectionHeader>
       {tickers.length === 0 ? (
-        <NoItem message="관련 종목이 없어요!" height={200} />
+        <NoItem
+          message={isLoading ? '검색 중...' : '관련 종목이 없어요!'}
+          height={200}
+        />
       ) : (
         <ListWrapper>
           {tickers.length >= displayCount && (

--- a/src/components/Search/SearchTickerSection.tsx
+++ b/src/components/Search/SearchTickerSection.tsx
@@ -1,0 +1,321 @@
+import styled from 'styled-components';
+import { useState, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { GrPrevious, GrNext } from 'react-icons/gr';
+import ApexChart from 'react-apexcharts';
+import { ApexOptions } from 'apexcharts';
+import { Text } from '@/components/common/typography/Text';
+import { useGetTickerSearchList } from '@/api/hooks/useGetTickerSearchList';
+import { usePutFavoriteTicker } from '@/api/hooks/usePutFavoriteTicker';
+import useIsMobile from '@/hooks/useIsMobile';
+import NoItem from '@/components/common/Layout/NoItem';
+import TickerCard from '@/components/common/TickerCard';
+
+type SearchTickerSectionProps = {
+  keyword: string;
+};
+
+const MORE_PRICE_DATA = [
+  476.99, 474, 472.12, 478.43, 487.12, 493.79, 507.49, 510.18, 503.29, 511.14,
+  508.68,
+];
+const MORE_CHART_DATA = MORE_PRICE_DATA.map((price, index) => ({
+  x: index,
+  y: price,
+}));
+
+export default function SearchTickerSection({
+  keyword,
+}: SearchTickerSectionProps) {
+  const [hoverKey, setHoverKey] = useState(0);
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const isMobile = useIsMobile();
+  const queryClient = useQueryClient();
+  const displayCount = isMobile ? 2 : 3;
+
+  const { data: searchData } = useGetTickerSearchList(keyword);
+  const { mutate: putFavoriteTicker } = usePutFavoriteTicker();
+  const tickers = searchData?.content.tickers ?? [];
+
+  const handleToggleLike = (tickerCode: string, isFavorite: boolean) => {
+    putFavoriteTicker(
+      { tickerCode, mode: isFavorite ? 'on' : 'off' },
+      {
+        onSuccess: () => {
+          queryClient.invalidateQueries({ queryKey: ['favoriteTickers'] });
+          queryClient.invalidateQueries({ queryKey: ['tickerSearchList'] });
+        },
+      }
+    );
+  };
+
+  const scrollList = (direction: 'left' | 'right') => {
+    if (!listRef.current) return;
+    const someWidth = 400;
+    const { scrollLeft, scrollWidth, clientWidth } = listRef.current;
+    const remainingScroll =
+      direction === 'left'
+        ? scrollLeft
+        : scrollWidth - clientWidth - scrollLeft;
+    const scrollAmount =
+      direction === 'left'
+        ? -Math.min(someWidth, remainingScroll)
+        : Math.min(someWidth, remainingScroll);
+    listRef.current.scrollBy({ left: scrollAmount, behavior: 'smooth' });
+  };
+
+  const moreChartOptions: ApexOptions = {
+    chart: {
+      sparkline: { enabled: true },
+      animations: {
+        enabled: true,
+        dynamicAnimation: { enabled: true },
+      },
+    },
+    colors: ['gray'],
+    stroke: { curve: 'smooth', width: isMobile ? 2 : 2.6 },
+    fill: {
+      type: 'gradient',
+      gradient: {
+        shade: 'light',
+        type: 'vertical',
+        shadeIntensity: 0.5,
+        gradientToColors: ['gray'],
+        inverseColors: false,
+        opacityFrom: 0.4,
+        opacityTo: 0.05,
+        stops: [0, 100],
+      },
+    },
+    markers: { size: 0 },
+    yaxis: {
+      show: false,
+      min: Math.min(...MORE_PRICE_DATA),
+      max: Math.max(...MORE_PRICE_DATA),
+    },
+    tooltip: { enabled: false },
+  };
+
+  return (
+    <SectionContainer>
+      <SectionHeader>
+        <Text size={isMobile ? 's' : 'm'} weight="bold">
+          관련 종목
+        </Text>
+      </SectionHeader>
+      {tickers.length === 0 ? (
+        <NoItem message="관련 종목이 없어요!" height={200} />
+      ) : (
+        <ListWrapper>
+          {tickers.length >= displayCount && (
+            <ArrowButton
+              aria-label="관련 종목 스크롤 왼쪽"
+              onClick={() => scrollList('left')}
+              className="left-arrow"
+              direction="left"
+            >
+              <GrPrevious size={40} />
+            </ArrowButton>
+          )}
+          <ListContainer ref={listRef}>
+            {tickers.map((ticker) => (
+              <TickerCard
+                key={ticker.tickerCode}
+                tickerId={ticker.tickerId}
+                tickerCode={ticker.tickerCode}
+                shortCompanyName={ticker.shortCompanyName}
+                predictionStrategy={ticker.predictionStrategy}
+                sentiment={ticker.sentiment}
+                graphData={
+                  ticker.graphData ?? { isMarketOpen: false, priceData: [] }
+                }
+                isSelected={ticker.isFavorite ?? false}
+                onToggleLike={handleToggleLike}
+              />
+            ))}
+            <MoreWrapper onMouseEnter={() => setHoverKey((k) => k + 1)}>
+              <MoreImageContainer>
+                <MoreGraphWrapper>
+                  <ApexChart
+                    key={hoverKey}
+                    options={moreChartOptions}
+                    series={[{ name: 'Price', data: MORE_CHART_DATA }]}
+                    type="area"
+                    height={isMobile ? 36 : 44}
+                  />
+                </MoreGraphWrapper>
+              </MoreImageContainer>
+              <MoreInfoContainer>
+                <Text size={isMobile ? 'xs' : 's'} weight="bold">
+                  관련 종목
+                </Text>
+                <Text
+                  size={isMobile ? 'xxs' : 'xs'}
+                  weight="bold"
+                  variant="grey"
+                >
+                  더 보기
+                </Text>
+              </MoreInfoContainer>
+            </MoreWrapper>
+          </ListContainer>
+          {tickers.length >= displayCount && (
+            <ArrowButton
+              aria-label="관련 종목 스크롤 오른쪽"
+              onClick={() => scrollList('right')}
+              className="right-arrow"
+              direction="right"
+            >
+              <GrNext size={40} />
+            </ArrowButton>
+          )}
+        </ListWrapper>
+      )}
+    </SectionContainer>
+  );
+}
+
+const SectionContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+`;
+
+const SectionHeader = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const ListWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  position: relative;
+  overflow: visible;
+  width: 100%;
+`;
+
+const ListContainer = styled.div`
+  display: flex;
+  gap: 16px;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  & > * {
+    flex-shrink: 0;
+    scroll-snap-align: start;
+  }
+`;
+
+const ArrowButton = styled.button<{ direction: 'left' | 'right' }>`
+  position: absolute;
+  height: 100%;
+  color: transparent;
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition:
+    color 0.3s,
+    background 0.3s;
+  padding: 0;
+  z-index: 9;
+
+  &:hover {
+    color: white;
+    background: ${({ direction }) =>
+      direction === 'left'
+        ? 'linear-gradient(to right, rgba(200, 200, 200, 0.5), transparent 90%)'
+        : 'linear-gradient(to left, rgba(200, 200, 200, 0.5), transparent 90%)'};
+  }
+
+  &.left-arrow {
+    left: 0;
+  }
+
+  &.right-arrow {
+    right: 0;
+  }
+
+  svg {
+    ${({ direction }) =>
+      direction === 'left' ? 'padding-right: 20px' : 'padding-left: 20px'};
+  }
+
+  @media screen and (max-width: 768px) {
+    svg {
+      height: 20px;
+    }
+  }
+`;
+
+const MoreWrapper = styled.div`
+  width: 154px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 4px;
+  border-radius: 8px;
+  background-color: #f7faff;
+  padding: 12px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #f4f7fc;
+  }
+
+  @media screen and (max-width: 768px) {
+    width: 120px;
+  }
+`;
+
+const MoreImageContainer = styled.div`
+  width: 150px;
+  aspect-ratio: 3 / 2;
+  position: relative;
+  border-radius: 6px;
+  overflow: hidden;
+  margin-bottom: 4px;
+
+  @media screen and (max-width: 768px) {
+    width: 116px;
+  }
+`;
+
+const MoreGraphWrapper = styled.div`
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 60%;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+
+  > div {
+    padding: 0 !important;
+    height: 100% !important;
+  }
+`;
+
+const MoreInfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  background-color: #ffffff;
+  border-radius: 8px;
+  width: 100%;
+  gap: 10px;
+  align-items: center;
+  justify-content: center;
+  padding: 18px 0;
+
+  @media screen and (max-width: 768px) {
+    padding: 16px 0;
+  }
+`;

--- a/src/mocks/searchHandler.ts
+++ b/src/mocks/searchHandler.ts
@@ -42,6 +42,32 @@ const mockArticleSearchData = [
     source: 'Researchandmarkets.Com',
     isFavorite: false,
   },
+  {
+    articleId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    title: 'AI Chip Market Surges as Demand for Inference Hardware Grows',
+    description:
+      'The AI chip market is seeing unprecedented growth as cloud providers and enterprises race to deploy inference hardware at scale.',
+    shortCompanyNames: ['NVDA', 'AMD', 'INTC'],
+    thumbnailUrl:
+      'https://ml.globenewswire.com/Resource/Download/dbcddd65-71dd-4559-8875-ae89ac4f96db',
+    contentUrl: 'https://www.globenewswire.com',
+    publishedDate: '2일 전',
+    source: 'TechCrunch',
+    isFavorite: false,
+  },
+  {
+    articleId: 'b2c3d4e5-f6a7-8901-bcde-f12345678901',
+    title: 'Global EV Market Outlook: Growth Slows in Key Regions',
+    description:
+      'The global electric vehicle market faces headwinds as subsidy cuts and infrastructure gaps dampen consumer demand in Europe and the US.',
+    shortCompanyNames: ['TSLA'],
+    thumbnailUrl:
+      'https://g.foolcdn.com/editorial/images/831487/artifical-intelligence-gettyimages-1276832742.jpg',
+    contentUrl: 'https://www.fool.com',
+    publishedDate: '3일 전',
+    source: 'Reuters',
+    isFavorite: false,
+  },
 ];
 
 const mockTickerSearchData = [
@@ -204,7 +230,182 @@ export const articleSearchHandlers = [
   }),
 ];
 
+const mockTickerSearchListData = [
+  {
+    tickerId: '0-d-q-8b-95n',
+    tickerCode: 'GOOGL',
+    shortCompanyName: 'Alphabet Inc.',
+    predictionStrategy: '약한매수',
+    sentiment: 1,
+  },
+  {
+    tickerId: '1-d-q-8b-95n',
+    tickerCode: 'AAPL',
+    shortCompanyName: 'Apple Inc.',
+    predictionStrategy: '강한매수',
+    sentiment: 2,
+  },
+  {
+    tickerId: '2-d-q-8b-95n',
+    tickerCode: 'META',
+    shortCompanyName: 'Meta Platforms',
+    predictionStrategy: '약한매수',
+    sentiment: 1,
+  },
+  {
+    tickerId: '3-d-q-8b-95n',
+    tickerCode: 'NFLX',
+    shortCompanyName: 'Netflix',
+    predictionStrategy: '강한매수',
+    sentiment: 2,
+  },
+  {
+    tickerId: '4-d-q-8b-95n',
+    tickerCode: 'COIN',
+    shortCompanyName: 'Coinbase',
+    predictionStrategy: '약한매도',
+    sentiment: -1,
+  },
+  {
+    tickerId: '5-d-q-8b-95n',
+    tickerCode: 'NVDA',
+    shortCompanyName: 'NVIDIA',
+    predictionStrategy: '강한매도',
+    sentiment: -2,
+  },
+  {
+    tickerId: '6-d-q-8b-95n',
+    tickerCode: 'TSLA',
+    shortCompanyName: 'Tesla',
+    predictionStrategy: '강한매수',
+    sentiment: 2,
+  },
+  {
+    tickerId: '7-d-q-8b-95n',
+    tickerCode: 'AMZN',
+    shortCompanyName: 'Amazon',
+    predictionStrategy: '관망',
+    sentiment: 0,
+  },
+  {
+    tickerId: '8-d-q-8b-95n',
+    tickerCode: 'PYPL',
+    shortCompanyName: 'PayPal',
+    predictionStrategy: '약한매도',
+    sentiment: -1,
+  },
+  {
+    tickerId: '9-d-q-8b-95n',
+    tickerCode: 'ZM',
+    shortCompanyName: 'Zoom',
+    predictionStrategy: '관망',
+    sentiment: 0,
+  },
+  {
+    tickerId: '10-d-q-8b-95n',
+    tickerCode: 'MSFT',
+    shortCompanyName: 'Microsoft',
+    predictionStrategy: '강한매수',
+    sentiment: 2,
+  },
+  {
+    tickerId: '11-d-q-8b-95n',
+    tickerCode: 'AMD',
+    shortCompanyName: 'AMD',
+    predictionStrategy: '약한매수',
+    sentiment: 1,
+  },
+  {
+    tickerId: '12-d-q-8b-95n',
+    tickerCode: 'INTC',
+    shortCompanyName: 'Intel',
+    predictionStrategy: '약한매도',
+    sentiment: -1,
+  },
+  {
+    tickerId: '13-d-q-8b-95n',
+    tickerCode: 'SAMSUNG',
+    shortCompanyName: '삼성전자',
+    predictionStrategy: '강한매수',
+    sentiment: 2,
+  },
+  {
+    tickerId: '14-d-q-8b-95n',
+    tickerCode: 'SK',
+    shortCompanyName: 'SK하이닉스',
+    predictionStrategy: '약한매수',
+    sentiment: 1,
+  },
+];
+
+export const tickerSearchListHandlers = [
+  http.get(`${BASE_URL}/api/v1/search/ticker`, ({ request }) => {
+    const url = new URL(request.url);
+    const keyword = url.searchParams.get('keyword') || '';
+
+    if (keyword.length < 2) {
+      return HttpResponse.json({
+        code: '200 OK',
+        message: '종목 검색 결과를 성공적으로 조회하였습니다.',
+        content: { tickers: [] },
+      });
+    }
+
+    const filtered = mockTickerSearchListData.filter(
+      (ticker) =>
+        ticker.shortCompanyName.toLowerCase().includes(keyword.toLowerCase()) ||
+        ticker.tickerCode.toLowerCase().includes(keyword.toLowerCase())
+    );
+
+    const tickers = filtered.map((ticker) => ({
+      ...ticker,
+      graphData: {
+        isMarketOpen: Math.random() > 0.5,
+        priceData: Array.from(
+          { length: 20 },
+          () => Math.floor(Math.random() * 500) + 100
+        ),
+      },
+    }));
+
+    return HttpResponse.json({
+      code: '200 OK',
+      message: '종목 검색 결과를 성공적으로 조회하였습니다.',
+      content: { tickers },
+    });
+  }),
+];
+
+export const articleSearchListHandlers = [
+  http.get(`${BASE_URL}/api/v1/search/article`, ({ request }) => {
+    const url = new URL(request.url);
+    const keyword = url.searchParams.get('keyword') || '';
+
+    if (keyword.length < 2) {
+      return HttpResponse.json({
+        code: '200 OK',
+        message: '기사 검색 결과를 성공적으로 조회하였습니다.',
+        content: { articles: [] },
+      });
+    }
+
+    const filtered = mockArticleSearchData.filter(
+      (article) =>
+        article.title.toLowerCase().includes(keyword.toLowerCase()) ||
+        article.description.toLowerCase().includes(keyword.toLowerCase())
+    );
+
+    return HttpResponse.json({
+      code: '200 OK',
+      message: '기사 검색 결과를 성공적으로 조회하였습니다.',
+      content: { articles: filtered },
+    });
+  }),
+];
+
 export const searchHandlers = [
   ...searchPreviewHandlers,
   ...articleSearchHandlers,
+  ...tickerSearchListHandlers,
+  ...articleSearchListHandlers,
 ];

--- a/src/pages/Search/index.tsx
+++ b/src/pages/Search/index.tsx
@@ -1,7 +1,68 @@
+import { styled } from 'styled-components';
+import { useSearchParams } from 'react-router-dom';
+import { Paragraph } from '@/components/common/typography/Paragraph';
+import { Text } from '@/components/common/typography/Text';
+import SearchTickerSection from '@/components/Search/SearchTickerSection';
+import SearchArticleSection from '@/components/Search/SearchArticleSection';
+
 export default function SearchPage() {
+  const [searchParams] = useSearchParams();
+  const keyword = searchParams.get('keyword') || '';
+
   return (
-    <div>
-      <h1>Search Page</h1>
-    </div>
+    <Wrapper>
+      <TitleWrapper>
+        <Paragraph weight="normal" size="m">
+          <Text weight="bold" size="m" variant="#2d70d3">
+            {`${keyword} `}
+          </Text>
+          검색 결과
+        </Paragraph>
+      </TitleWrapper>
+      <SearchListSection>
+        <SearchTickerSection keyword={keyword} />
+        <SearchArticleSection keyword={keyword} />
+      </SearchListSection>
+    </Wrapper>
   );
 }
+
+const Wrapper = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 30px 0px 0px 0px;
+
+  @media screen and (max-width: 768px) {
+    width: 100%;
+    gap: 30px;
+    align-items: center;
+  }
+`;
+
+const TitleWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 20px;
+
+  @media screen and (max-width: 768px) {
+    width: 90%;
+    gap: 10px;
+    margin-bottom: 10px;
+  }
+`;
+
+const SearchListSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+  margin-bottom: 40px;
+
+  @media screen and (max-width: 768px) {
+    width: 90%;
+    gap: 30px;
+    margin-bottom: 10px;
+  }
+`;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -282,5 +282,5 @@ export type ArticleSearchListResponse = {
 };
 
 export type TickerSearchListResponse = {
-  tickers: FavoriteTickerResponse[];
+  tickers: PredictionDataResponse[]; // 추후 수정 필요
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -276,3 +276,11 @@ export type TickerRealTimeStreamResponse = {
   close: number;
   volume: number;
 };
+
+export type ArticleSearchListResponse = {
+  articles: ArticleDataResponse[];
+};
+
+export type TickerSearchListResponse = {
+  tickers: FavoriteTickerResponse[];
+};


### PR DESCRIPTION
### ✨ 작업 내용
- [x] 통합 검색 결과 페이지(`SearchPage`) 구현
- [x] 관련 종목 섹션(`SearchTickerSection`) 구현 - 좌우 스크롤 오버레이 화살표 포함
- [x] 관련 기사 섹션(`SearchArticleSection`) 구현 - 최대 3개 노출, 초과 시 더 보기 버튼 노출
- [x] 검색 결과 조회 API 훅 추가 (`useGetArticleSearchList`, `useGetTickerSearchList`)
- [x] 검색 결과 MSW mock 데이터 추가

---

### ✨ 참고 사항
- `TickerSearchListResponse` 타입을 `PredictionDataResponse[]`로 임시 변경함 (`isFavorite` 필드 포함을 위해) → 백엔드 타입 확정 후 수정 필요
- 관련 기사 섹션의 더 보기 버튼은 현재 `/news`로 이동하며, 추후 키워드 필터링된 뉴스 페이지로 수정 필요

---

### ⏰ 현재 버그

---

### ✏ Git Close
