### PR TITLE
[Articker - 34] 검색 키워드 기반 필터링 기능 추가

### DIFF
--- a/src/api/hooks/useGetInfiniteArticleList.ts
+++ b/src/api/hooks/useGetInfiniteArticleList.ts
@@ -7,6 +7,7 @@ interface ArticleListParams {
   sentiment?: 'positive' | 'negative';
   sort: 'recent';
   tickerCode?: string[];
+  filter?: string;
 }
 
 export const getInfiniteArticleListPath = () => `/api/v1/article`;
@@ -16,6 +17,7 @@ export const getInfiniteArticleList = async ({
   sort,
   page,
   tickerCode,
+  filter,
 }: ArticleListParams & { page: number }) => {
   const params = new URLSearchParams({
     sort,
@@ -32,6 +34,8 @@ export const getInfiniteArticleList = async ({
     params.append('sentiment', sentiment);
   }
 
+  if (filter) params.set('filter', filter);
+
   const response = await fetchInstance.get<PageableData<ArticleListData>>(
     `${getInfiniteArticleListPath()}?${params}`
   );
@@ -42,11 +46,24 @@ export const useGetInfiniteArticleList = ({
   sentiment,
   sort,
   tickerCode,
+  filter,
 }: ArticleListParams) => {
   return useInfiniteQuery({
-    queryKey: ['articleList', tickerCode || [], sentiment || null, sort],
+    queryKey: [
+      'articleList',
+      tickerCode || [],
+      sentiment || null,
+      sort,
+      filter,
+    ],
     queryFn: ({ pageParam = 0 }) =>
-      getInfiniteArticleList({ sentiment, sort, page: pageParam, tickerCode }),
+      getInfiniteArticleList({
+        sentiment,
+        sort,
+        page: pageParam,
+        tickerCode,
+        filter,
+      }),
     initialPageParam: 0,
     getNextPageParam: (lastPage, allPages) => {
       if (lastPage.content.hasNext) {

--- a/src/api/hooks/useGetInfiniteTickerList.ts
+++ b/src/api/hooks/useGetInfiniteTickerList.ts
@@ -5,6 +5,7 @@ import { PageableData, TickerListData } from '@/types';
 
 interface GetTickerListParams {
   sort: string;
+  filter?: string;
 }
 
 export const getInfiniteTickerListPath = () => `/api/v1/prediction/ticker`;
@@ -12,11 +13,13 @@ export const getInfiniteTickerListPath = () => `/api/v1/prediction/ticker`;
 export const getInfiniteTickerList = async ({
   sort,
   page,
+  filter,
 }: GetTickerListParams & { page: number }) => {
   const params = new URLSearchParams({
     sort,
     page: page.toString(),
   });
+  if (filter) params.set('filter', filter);
 
   const response = await fetchInstance.get<PageableData<TickerListData>>(
     `${getInfiniteTickerListPath()}?${params}`
@@ -24,11 +27,14 @@ export const getInfiniteTickerList = async ({
   return response.data;
 };
 
-export const useGetInfiniteTickerList = ({ sort }: GetTickerListParams) => {
+export const useGetInfiniteTickerList = ({
+  sort,
+  filter,
+}: GetTickerListParams) => {
   return useInfiniteQuery({
-    queryKey: ['tickerList', { sort }],
+    queryKey: ['tickerList', { sort, filter }],
     queryFn: ({ pageParam = 0 }) =>
-      getInfiniteTickerList({ sort, page: pageParam }),
+      getInfiniteTickerList({ sort, page: pageParam, filter }),
     initialPageParam: 0,
     getNextPageParam: (lastPage, allPages) => {
       if (lastPage.content.hasNext) {

--- a/src/components/Search/SearchArticleSection.tsx
+++ b/src/components/Search/SearchArticleSection.tsx
@@ -31,8 +31,11 @@ export default function SearchArticleSection({
           관련 기사
         </Text>
         {hasMore && (
-          // 추후 필터링 된 뉴스 페이지로 수정 필요
-          <MoreBtn onClick={() => navigate('/news')}>
+          <MoreBtn
+            onClick={() =>
+              navigate(`/news?filter=${encodeURIComponent(keyword)}`)
+            }
+          >
             더 보기
             <IoIosArrowForward />
           </MoreBtn>

--- a/src/components/Search/SearchTickerSection.tsx
+++ b/src/components/Search/SearchTickerSection.tsx
@@ -267,6 +267,7 @@ const ArrowButton = styled.button<{ direction: 'left' | 'right' }>`
 `;
 
 const MoreBtn = styled.button`
+  box-sizing: content-box;
   border: none;
   width: 154px;
   display: flex;

--- a/src/components/Search/SearchTickerSection.tsx
+++ b/src/components/Search/SearchTickerSection.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { useState, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { GrPrevious, GrNext } from 'react-icons/gr';
 import ApexChart from 'react-apexcharts';
@@ -30,6 +31,7 @@ export default function SearchTickerSection({
   const [hoverKey, setHoverKey] = useState(0);
   const listRef = useRef<HTMLDivElement | null>(null);
   const isMobile = useIsMobile();
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const displayCount = isMobile ? 2 : 3;
 
@@ -136,7 +138,12 @@ export default function SearchTickerSection({
                 onToggleLike={handleToggleLike}
               />
             ))}
-            <MoreWrapper onMouseEnter={() => setHoverKey((k) => k + 1)}>
+            <MoreWrapper
+              onMouseEnter={() => setHoverKey((k) => k + 1)}
+              onClick={() =>
+                navigate(`/ticker?filter=${encodeURIComponent(keyword)}`)
+              }
+            >
               <MoreImageContainer>
                 <MoreGraphWrapper>
                   <ApexChart

--- a/src/components/Search/SearchTickerSection.tsx
+++ b/src/components/Search/SearchTickerSection.tsx
@@ -138,7 +138,9 @@ export default function SearchTickerSection({
                 onToggleLike={handleToggleLike}
               />
             ))}
-            <MoreWrapper
+            <MoreBtn
+              type="button"
+              aria-label={`${keyword} 관련 종목 더 보기`}
               onMouseEnter={() => setHoverKey((k) => k + 1)}
               onClick={() =>
                 navigate(`/ticker?filter=${encodeURIComponent(keyword)}`)
@@ -167,7 +169,7 @@ export default function SearchTickerSection({
                   더 보기
                 </Text>
               </MoreInfoContainer>
-            </MoreWrapper>
+            </MoreBtn>
           </ListContainer>
           {tickers.length >= displayCount && (
             <ArrowButton
@@ -264,7 +266,8 @@ const ArrowButton = styled.button<{ direction: 'left' | 'right' }>`
   }
 `;
 
-const MoreWrapper = styled.div`
+const MoreBtn = styled.button`
+  border: none;
   width: 154px;
   display: flex;
   flex-direction: column;

--- a/src/pages/NewsBoard/index.tsx
+++ b/src/pages/NewsBoard/index.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useInView } from 'react-intersection-observer';
 import styled from 'styled-components';
+import { Paragraph } from '@/components/common/typography/Paragraph';
+import { Text } from '@/components/common/typography/Text';
 import SearchBar from '@/components/common/SearchBar';
 import ArticleList from '@/components/Article/ArticleList';
 import { useGetInfiniteArticleList } from '@/api/hooks/useGetInfiniteArticleList';
@@ -184,6 +186,16 @@ export default function NewsBoardPage() {
         />
       </ChipContainer>
 
+      {filterOption && (
+        <FilterKeywordContainer>
+          <Paragraph weight="normal" size="sm">
+            <Text weight="bold" size="sm" variant="#2d70d3">
+              {`${filterOption} `}
+            </Text>
+            로 검색한 결과입니다.
+          </Paragraph>
+        </FilterKeywordContainer>
+      )}
       <ArticleList items={allArticles} />
       <div ref={ref} style={{ height: '50px' }} />
       {isFetchingNextPage && <Loading />}
@@ -247,6 +259,14 @@ const ChipContainer = styled.div`
 
   @media screen and (max-width: 768px) {
     margin: -6px 0 -16px 0;
+  }
+`;
+
+export const FilterKeywordContainer = styled.div`
+  margin: -30px 0 -40px 0;
+
+  @media screen and (max-width: 768px) {
+    margin: -30px 0 -30px 0;
   }
 `;
 

--- a/src/pages/NewsBoard/index.tsx
+++ b/src/pages/NewsBoard/index.tsx
@@ -10,7 +10,6 @@ import DropdownFilterBar from '@/components/Article/FilterDropdown';
 import { useGetFilterTickerList } from '@/api/hooks/useGetFilterTickerList';
 import Chip from '@/components/Article/FilterChip';
 import useIsMobile from '@/hooks/useIsMobile';
-import { ArticleDataResponse } from '@/types';
 
 type NewsSentiment = 'positive' | 'negative';
 type NewsSort = 'recent';
@@ -34,10 +33,9 @@ export default function NewsBoardPage() {
     getInitialSentiment()
   );
   const [sort] = useState<NewsSort>('recent');
+  const filterOption =
+    new URLSearchParams(location.search).get('filter') ?? undefined;
   const [isInitialLoad, setIsInitialLoad] = useState(true);
-  const [searchArticles, setSearchArticles] = useState<
-    ArticleDataResponse[] | null
-  >(null);
   const { ref, inView } = useInView();
   const currentTickerCodes = getTickerCodes();
 
@@ -52,6 +50,7 @@ export default function NewsBoardPage() {
     tickerCode: currentTickerCodes.length > 0 ? currentTickerCodes : undefined,
     sentiment: sentiment || undefined,
     sort,
+    filter: filterOption,
   });
 
   const { data: filterTickerData } = useGetFilterTickerList();
@@ -136,7 +135,7 @@ export default function NewsBoardPage() {
 
   return (
     <Wrapper>
-      <SearchBar onArticleSearchResult={setSearchArticles} />
+      <SearchBar />
 
       <FilterContainer>
         <FilterTabsGroup>
@@ -185,15 +184,9 @@ export default function NewsBoardPage() {
         />
       </ChipContainer>
 
-      {searchArticles ? (
-        <ArticleList items={searchArticles} />
-      ) : (
-        <>
-          <ArticleList items={allArticles} />
-          <div ref={ref} style={{ height: '50px' }} />
-          {isFetchingNextPage && <Loading />}
-        </>
-      )}
+      <ArticleList items={allArticles} />
+      <div ref={ref} style={{ height: '50px' }} />
+      {isFetchingNextPage && <Loading />}
     </Wrapper>
   );
 }

--- a/src/pages/Ticker/index.tsx
+++ b/src/pages/Ticker/index.tsx
@@ -20,6 +20,8 @@ export default function TickerPage() {
   };
 
   const [sortOption, setSortOption] = useState(getInitialSortOption());
+  const filterOption =
+    new URLSearchParams(location.search).get('filter') ?? undefined;
   const [showSortOptions, setShowSortOptions] = useState(false);
 
   const handleSortChange = (option: string) => {
@@ -39,7 +41,7 @@ export default function TickerPage() {
     hasNextPage: hasNext,
     isFetchingNextPage,
     fetchNextPage,
-  } = useGetInfiniteTickerList({ sort: sortOption });
+  } = useGetInfiniteTickerList({ sort: sortOption, filter: filterOption });
   const sortLabel: Record<string, string> = {
     popular: '인기순',
     upward: '점수 낮은순',

--- a/src/pages/Ticker/index.tsx
+++ b/src/pages/Ticker/index.tsx
@@ -8,6 +8,9 @@ import Loading from '@/components/common/Layout/Loading';
 import SearchBar from '@/components/common/SearchBar';
 import Button from '@/components/common/Button';
 import { IoIosArrowDown } from 'react-icons/io';
+import { Paragraph } from '@/components/common/typography/Paragraph';
+import { Text } from '@/components/common/typography/Text';
+
 export default function TickerPage() {
   const [isInitialLoad, setIsInitialLoad] = useState(true);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -80,6 +83,16 @@ export default function TickerPage() {
     <Wrapper>
       <SearchBar />
       <SortSection ref={dropdownRef}>
+        {filterOption && (
+          <FilterKeywordContainer>
+            <Paragraph weight="normal" size="sm">
+              <Text weight="bold" size="sm" variant="#2d70d3">
+                {`${filterOption} `}
+              </Text>
+              로 검색한 결과입니다.
+            </Paragraph>
+          </FilterKeywordContainer>
+        )}
         <StyledButton
           aria-label="티커 정렬"
           variant="white"
@@ -135,8 +148,9 @@ const ErrorMessage = styled.div`
 const SortSection = styled.div`
   position: relative;
   display: flex;
-  justify-content: flex-end;
-  margin: -10px 0;
+  justify-content: space-between;
+  align-items: center;
+  margin: -14px 0;
 
   @media screen and (max-width: 768px) {
   }
@@ -225,5 +239,13 @@ const SortItem = styled.div`
       border-bottom-left-radius: 4px;
       border-bottom-right-radius: 4px;
     }
+  }
+`;
+
+const FilterKeywordContainer = styled.div`
+  margin: 8px 0 0 0;
+
+  @media screen and (max-width: 768px) {
+    margin: 4px 0 0 0;
   }
 `;


### PR DESCRIPTION
### ✨ 작업 내용
- [x] 아티클 리스트 조회 API에 필터링 파라미터(`filter`, `sentiment`, `tickerCode`) 추가
- [x] 뉴스보드 검색 시 하단 즉시 필터링 제거 (검색 결과를 별도 state로 관리하던 방식 → API 파라미터 방식으로 전환)
- [x] 종목 리스트 조회 API에 필터링 파라미터(`filter`, `sort`) 추가
- [x] 검색 키워드(`filter`) 존재 시 "OO 로 검색한 결과입니다." 안내 문구 조건부 표시 (뉴스보드, 종목 페이지)

---

### ✨ 참고 사항
- 기존에는 검색 결과를 `searchArticles` state로 관리하며 하단에서 직접 필터링했으나, API 파라미터로 통합하여 일관된 방식으로 변경
- `filter` 값은 URL 쿼리 파라미터(`?filter=...`)에서 읽어 API 호출 시 전달

---

### ⏰ 현재 버그

---

### ✏ Git Close