### PR TITLE
[Articker - 35] 검색 결과 데이터에 isMore 필드 추가

### DIFF
--- a/src/components/Search/SearchArticleSection.tsx
+++ b/src/components/Search/SearchArticleSection.tsx
@@ -22,7 +22,7 @@ export default function SearchArticleSection({
   const { data: searchData, isLoading } = useGetArticleSearchList(keyword);
   const allArticles = searchData?.content.articles ?? [];
   const articles = allArticles.slice(0, ARTICLE_LIMIT);
-  const hasMore = allArticles.length > ARTICLE_LIMIT;
+  const hasMore = searchData?.content.isMore ?? false;
 
   return (
     <SectionContainer>

--- a/src/components/Search/SearchTickerSection.tsx
+++ b/src/components/Search/SearchTickerSection.tsx
@@ -37,7 +37,7 @@ export default function SearchTickerSection({
 
   const { data: searchData, isLoading } = useGetTickerSearchList(keyword);
   const { mutate: putFavoriteTicker } = usePutFavoriteTicker();
-  const tickers = searchData?.content.tickers ?? [];
+  const tickers = searchData?.content.tickerSearchList ?? [];
   const hasMore = searchData?.content.isMore ?? false;
 
   const handleToggleLike = (tickerCode: string, isFavorite: boolean) => {

--- a/src/components/Search/SearchTickerSection.tsx
+++ b/src/components/Search/SearchTickerSection.tsx
@@ -38,6 +38,7 @@ export default function SearchTickerSection({
   const { data: searchData, isLoading } = useGetTickerSearchList(keyword);
   const { mutate: putFavoriteTicker } = usePutFavoriteTicker();
   const tickers = searchData?.content.tickers ?? [];
+  const hasMore = searchData?.content.isMore ?? false;
 
   const handleToggleLike = (tickerCode: string, isFavorite: boolean) => {
     putFavoriteTicker(
@@ -138,38 +139,40 @@ export default function SearchTickerSection({
                 onToggleLike={handleToggleLike}
               />
             ))}
-            <MoreBtn
-              type="button"
-              aria-label={`${keyword} 관련 종목 더 보기`}
-              onMouseEnter={() => setHoverKey((k) => k + 1)}
-              onClick={() =>
-                navigate(`/ticker?filter=${encodeURIComponent(keyword)}`)
-              }
-            >
-              <MoreImageContainer>
-                <MoreGraphWrapper>
-                  <ApexChart
-                    key={hoverKey}
-                    options={moreChartOptions}
-                    series={[{ name: 'Price', data: MORE_CHART_DATA }]}
-                    type="area"
-                    height={isMobile ? 36 : 44}
-                  />
-                </MoreGraphWrapper>
-              </MoreImageContainer>
-              <MoreInfoContainer>
-                <Text size={isMobile ? 'xs' : 's'} weight="bold">
-                  관련 종목
-                </Text>
-                <Text
-                  size={isMobile ? 'xxs' : 'xs'}
-                  weight="bold"
-                  variant="grey"
-                >
-                  더 보기
-                </Text>
-              </MoreInfoContainer>
-            </MoreBtn>
+            {hasMore && (
+              <MoreBtn
+                type="button"
+                aria-label={`${keyword} 관련 종목 더 보기`}
+                onMouseEnter={() => setHoverKey((k) => k + 1)}
+                onClick={() =>
+                  navigate(`/ticker?filter=${encodeURIComponent(keyword)}`)
+                }
+              >
+                <MoreImageContainer>
+                  <MoreGraphWrapper>
+                    <ApexChart
+                      key={hoverKey}
+                      options={moreChartOptions}
+                      series={[{ name: 'Price', data: MORE_CHART_DATA }]}
+                      type="area"
+                      height={isMobile ? 36 : 44}
+                    />
+                  </MoreGraphWrapper>
+                </MoreImageContainer>
+                <MoreInfoContainer>
+                  <Text size={isMobile ? 'xs' : 's'} weight="bold">
+                    관련 종목
+                  </Text>
+                  <Text
+                    size={isMobile ? 'xxs' : 'xs'}
+                    weight="bold"
+                    variant="grey"
+                  >
+                    더 보기
+                  </Text>
+                </MoreInfoContainer>
+              </MoreBtn>
+            )}
           </ListContainer>
           {tickers.length >= displayCount && (
             <ArrowButton

--- a/src/mocks/searchHandler.ts
+++ b/src/mocks/searchHandler.ts
@@ -347,7 +347,7 @@ export const tickerSearchListHandlers = [
       return HttpResponse.json({
         code: '200 OK',
         message: '종목 검색 결과를 성공적으로 조회하였습니다.',
-        content: { tickers: [] },
+        content: { tickers: [], isMore: false },
       });
     }
 
@@ -371,7 +371,7 @@ export const tickerSearchListHandlers = [
     return HttpResponse.json({
       code: '200 OK',
       message: '종목 검색 결과를 성공적으로 조회하였습니다.',
-      content: { tickers },
+      content: { tickers, isMore: filtered.length > 3 },
     });
   }),
 ];
@@ -385,7 +385,7 @@ export const articleSearchListHandlers = [
       return HttpResponse.json({
         code: '200 OK',
         message: '기사 검색 결과를 성공적으로 조회하였습니다.',
-        content: { articles: [] },
+        content: { articles: [], isMore: false },
       });
     }
 
@@ -398,7 +398,7 @@ export const articleSearchListHandlers = [
     return HttpResponse.json({
       code: '200 OK',
       message: '기사 검색 결과를 성공적으로 조회하였습니다.',
-      content: { articles: filtered },
+      content: { articles: filtered, isMore: filtered.length > 3 },
     });
   }),
 ];

--- a/src/mocks/searchHandler.ts
+++ b/src/mocks/searchHandler.ts
@@ -347,7 +347,7 @@ export const tickerSearchListHandlers = [
       return HttpResponse.json({
         code: '200 OK',
         message: '종목 검색 결과를 성공적으로 조회하였습니다.',
-        content: { tickers: [], isMore: false },
+        content: { tickerSearchList: [], isMore: false },
       });
     }
 
@@ -371,7 +371,7 @@ export const tickerSearchListHandlers = [
     return HttpResponse.json({
       code: '200 OK',
       message: '종목 검색 결과를 성공적으로 조회하였습니다.',
-      content: { tickers, isMore: filtered.length > 3 },
+      content: { tickerSearchList: tickers, isMore: filtered.length > 3 },
     });
   }),
 ];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -283,6 +283,6 @@ export type ArticleSearchListResponse = {
 };
 
 export type TickerSearchListResponse = {
-  tickers: PredictionDataResponse[];
+  tickerSearchList: PredictionDataResponse[];
   isMore: boolean;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -279,8 +279,10 @@ export type TickerRealTimeStreamResponse = {
 
 export type ArticleSearchListResponse = {
   articles: ArticleDataResponse[];
+  isMore: boolean;
 };
 
 export type TickerSearchListResponse = {
-  tickers: PredictionDataResponse[]; // 추후 수정 필요
+  tickers: PredictionDataResponse[];
+  isMore: boolean;
 };


### PR DESCRIPTION
### ✨ 작업 내용
- [x] 종목 검색 결과 더 보기 버튼(`MoreBtn`)을 `isMore` 필드 기반 조건부 렌더링으로 전환
- [x] 종목 검색 응답 키를 `tickers` → `tickerSearchList`로 통일 (타입, 컴포넌트, mock)

---

### ✨ 참고 사항

---

### ⏰ 현재 버그

---

### ✏ Git Close
