### PR TITLE
[Articker - 36] 검색 결과 조사 처리 및 글자 크기 확대

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tanstack/react-query": "^5.80.6",
         "axios": "^1.9.0",
+        "es-hangul": "^2.3.8",
         "react": "^19.1.0",
         "react-apexcharts": "^1.7.0",
         "react-dom": "^19.1.0",
@@ -2424,6 +2425,11 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-hangul": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/es-hangul/-/es-hangul-2.3.8.tgz",
+      "integrity": "sha512-VrJuqYBC7W04aKYjCnswomuJNXQRc0q33SG1IltVrRofi2YEE6FwVDPlsEJIdKbHwsOpbBL/mk9sUaBxVpbd+w=="
     },
     "node_modules/es-iterator-helpers": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@tanstack/react-query": "^5.80.6",
     "axios": "^1.9.0",
+    "es-hangul": "^2.3.8",
     "react": "^19.1.0",
     "react-apexcharts": "^1.7.0",
     "react-dom": "^19.1.0",

--- a/src/pages/NewsBoard/index.tsx
+++ b/src/pages/NewsBoard/index.tsx
@@ -1,3 +1,4 @@
+import { josa } from 'es-hangul';
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useInView } from 'react-intersection-observer';
@@ -192,7 +193,7 @@ export default function NewsBoardPage() {
             <Text weight="bold" size="sm" variant="#2d70d3">
               {`${filterOption} `}
             </Text>
-            로 검색한 결과입니다.
+            {josa.pick(filterOption, '으로/로')} 검색한 결과입니다.
           </Paragraph>
         </FilterKeywordContainer>
       )}

--- a/src/pages/NewsBoard/index.tsx
+++ b/src/pages/NewsBoard/index.tsx
@@ -189,8 +189,8 @@ export default function NewsBoardPage() {
 
       {filterOption && (
         <FilterKeywordContainer>
-          <Paragraph weight="normal" size="sm">
-            <Text weight="bold" size="sm" variant="#2d70d3">
+          <Paragraph weight="normal" size="s">
+            <Text weight="bold" size="s" variant="#2d70d3">
               {`${filterOption} `}
             </Text>
             {josa.pick(filterOption, '으로/로')} 검색한 결과입니다.

--- a/src/pages/Ticker/index.tsx
+++ b/src/pages/Ticker/index.tsx
@@ -1,3 +1,4 @@
+import { josa } from 'es-hangul';
 import TickerList from '@/components/Ticker/TickerList';
 import styled from 'styled-components';
 import { useGetInfiniteTickerList } from '@/api/hooks/useGetInfiniteTickerList';
@@ -89,7 +90,7 @@ export default function TickerPage() {
               <Text weight="bold" size="sm" variant="#2d70d3">
                 {`${filterOption} `}
               </Text>
-              로 검색한 결과입니다.
+              {josa.pick(filterOption, '으로/로')} 검색한 결과입니다.
             </Paragraph>
           </FilterKeywordContainer>
         )}

--- a/src/pages/Ticker/index.tsx
+++ b/src/pages/Ticker/index.tsx
@@ -86,8 +86,8 @@ export default function TickerPage() {
       <SortSection ref={dropdownRef}>
         {filterOption && (
           <FilterKeywordContainer>
-            <Paragraph weight="normal" size="sm">
-              <Text weight="bold" size="sm" variant="#2d70d3">
+            <Paragraph weight="normal" size="s">
+              <Text weight="bold" size="s" variant="#2d70d3">
                 {`${filterOption} `}
               </Text>
               {josa.pick(filterOption, '으로/로')} 검색한 결과입니다.


### PR DESCRIPTION
### ✨ 작업 내용
- [x] es-hangul 도입으로 검색 결과 조사(로/으로) 자동 처리
- [x] 검색 결과 문구 글자 크기 확대 (16px → 18px)

---

### ✨ 참고 사항

- [`josa` 함수](https://es-hangul.slash.page/docs/api/core/josa)
문자열에 올바른 조사를 붙여 반환하는 함수
현재 검색 결과 페이지의 Paragraph는 `filterOption`과 별도 컴포넌트로 분리되어 있어서 단어 없이 조사만 반환하는 `josa.pick`을 사용

- [`josa.pick`](https://es-hangul.slash.page/docs/api/core/josa.pick.ko)
주어진 문자열과 조사 옵션에 따라 적절한 조사만 선택하여 반환하는 `josa`의 프로퍼티 함수

- 도입 결과
  <table>
    <tr>
      <td><img width="400" height="484" alt="image" src="https://github.com/user-attachments/assets/0a5e7586-7c71-4e08-a69e-5a2d3dd01e21" /></td>
      <td><img width="400" height="481" alt="image" src="https://github.com/user-attachments/assets/d18111bf-06b8-411e-ba79-5a7c78b79686" /></td>
    </tr>
  </table>

---

### ⏰ 현재 버그
- _market_ 처럼 영어 문자열이 주어지면, `hasBatchim`이 한국어 유니코드 범위(`0xAC00~0xD7A3`) 밖의 문자를 받침 없음으로 간주하여 항상 '로'를 반환(영어뿐 아니라 숫자, 특수문자도 동일하게 적용됨)
---

### ✏ Git Close