### PR TITLE
[Articker - 38] 종목 상세 페이지에 들어갈 키워드 버블 맵 컴포넌트 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@tanstack/react-query": "^5.80.6",
         "axios": "^1.9.0",
         "es-hangul": "^2.3.8",
+        "framer-motion": "^12.40.0",
         "react": "^19.1.0",
         "react-apexcharts": "^1.7.0",
         "react-dom": "^19.1.0",
@@ -4422,6 +4423,32 @@
         "node": ">= 6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.40.0.tgz",
+      "integrity": "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==",
+      "dependencies": {
+        "motion-dom": "^12.40.0",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "dev": true,
@@ -5620,6 +5647,19 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.40.0.tgz",
+      "integrity": "sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==",
+      "dependencies": {
+        "motion-utils": "^12.39.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ=="
     },
     "node_modules/mrmime": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@tanstack/react-query": "^5.80.6",
     "axios": "^1.9.0",
     "es-hangul": "^2.3.8",
+    "framer-motion": "^12.40.0",
     "react": "^19.1.0",
     "react-apexcharts": "^1.7.0",
     "react-dom": "^19.1.0",

--- a/src/api/hooks/useGetTickerKeywords.ts
+++ b/src/api/hooks/useGetTickerKeywords.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import type { ApiResponse, KeywordsWithArticleListResponse } from '@/types';
+import { fetchInstance } from '../instance';
+
+export const getTickerKeywordsPath = (tickerId: string, date: string) =>
+  `/api/v1/prediction/ticker/${tickerId}/keywords?date=${date}`;
+
+export const getTickerKeywords = async (tickerId: string, date: string) => {
+  const response = await fetchInstance.get<
+    ApiResponse<KeywordsWithArticleListResponse>
+  >(getTickerKeywordsPath(tickerId, date));
+  return response.data;
+};
+
+export const useGetTickerKeywords = (tickerId: string, date: string) => {
+  return useQuery({
+    queryKey: ['tickerKeywords', tickerId, date],
+    queryFn: () => getTickerKeywords(tickerId, date),
+    staleTime: 1000 * 60 * 5,
+  });
+};

--- a/src/components/Detail/KeywordBubbleMap/KeywordBubbleMap.stories.tsx
+++ b/src/components/Detail/KeywordBubbleMap/KeywordBubbleMap.stories.tsx
@@ -1,0 +1,143 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import KeywordBubbleMap from './index';
+import type { KeywordsWithArticleResponse } from '@/types';
+
+const mockPositiveKeywords: KeywordsWithArticleResponse[] = [
+  {
+    keyword: '실적호조',
+    articles: [
+      { articleId: 'a1', title: '삼성전자 실적 호조로 주가 급등' },
+      { articleId: 'a2', title: '애플 신제품 출시 기대감 확산' },
+      { articleId: 'a3', title: 'AI 반도체 수요 폭발적 증가세' },
+    ],
+    sentiment: 1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: 'AI반도체',
+    articles: [{ articleId: 'a3', title: 'AI 반도체 수요 폭발적 증가세' }],
+    sentiment: 1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: '외국인매수',
+    articles: [
+      { articleId: 'a4', title: '코스피 외국인 순매수 전환' },
+      { articleId: 'a5', title: '2분기 실적 시장 기대치 상회' },
+    ],
+    sentiment: 1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: '신제품기대',
+    articles: [
+      { articleId: 'a2', title: '애플 신제품 출시 기대감 확산' },
+      { articleId: 'a1', title: '삼성전자 실적 호조로 주가 급등' },
+      { articleId: 'a5', title: '2분기 실적 시장 기대치 상회' },
+      { articleId: 'a3', title: 'AI 반도체 수요 폭발적 증가세' },
+      { articleId: 'a4', title: '코스피 외국인 순매수 전환' },
+    ],
+    sentiment: 1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: '어닝서프라이즈',
+    articles: [
+      { articleId: 'a5', title: '2분기 실적 시장 기대치 상회' },
+      { articleId: 'a3', title: 'AI 반도체 수요 폭발적 증가세' },
+      { articleId: 'a1', title: '삼성전자 실적 호조로 주가 급등' },
+      { articleId: 'a2', title: '애플 신제품 출시 기대감 확산' },
+    ],
+    sentiment: 1,
+    date: '2025-05-29',
+  },
+];
+
+const mockNegativeKeywords: KeywordsWithArticleResponse[] = [
+  {
+    keyword: '금리인상',
+    articles: [
+      { articleId: 'b1', title: '금리 인상 우려에 증시 하락' },
+      { articleId: 'b5', title: '인플레이션 예상치 웃돌아' },
+      { articleId: 'b3', title: '달러 강세 수출주 압박' },
+    ],
+    sentiment: -1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: '중국침체',
+    articles: [
+      { articleId: 'b2', title: '중국 경기 침체 공포 확산' },
+      { articleId: 'b4', title: '반도체 공급 과잉 우려 지속' },
+    ],
+    sentiment: -1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: '달러강세',
+    articles: [
+      { articleId: 'b3', title: '달러 강세 수출주 압박' },
+      { articleId: 'b1', title: '금리 인상 우려에 증시 하락' },
+    ],
+    sentiment: -1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: '공급과잉',
+    articles: [
+      { articleId: 'b4', title: '반도체 공급 과잉 우려 지속' },
+      { articleId: 'b2', title: '중국 경기 침체 공포 확산' },
+      { articleId: 'b5', title: '인플레이션 예상치 웃돌아' },
+    ],
+    sentiment: -1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: '인플레이션',
+    articles: [
+      { articleId: 'b5', title: '인플레이션 예상치 웃돌아' },
+      { articleId: 'b1', title: '금리 인상 우려에 증시 하락' },
+    ],
+    sentiment: -1,
+    date: '2025-05-29',
+  },
+];
+
+const meta: Meta<typeof KeywordBubbleMap> = {
+  title: 'Detail/KeywordBubbleMap',
+  component: KeywordBubbleMap,
+  args: {
+    positiveRatio: 50,
+    negativeRatio: 50,
+    positiveKeywords: mockPositiveKeywords,
+    negativeKeywords: mockNegativeKeywords,
+    date: '2025-05-29',
+    onNewsClick: (id) => alert(`뉴스 클릭: ${id}`),
+  },
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof KeywordBubbleMap>;
+
+export const Default: Story = {};
+
+export const HighPositiveRatio: Story = {
+  args: {
+    positiveRatio: 80,
+    negativeRatio: 20,
+    positiveKeywords: mockPositiveKeywords,
+    negativeKeywords: mockNegativeKeywords.slice(0, 2),
+  },
+};
+
+export const LowPositiveRatio: Story = {
+  args: {
+    positiveRatio: 20,
+    negativeRatio: 80,
+    positiveKeywords: mockPositiveKeywords.slice(0, 2),
+    negativeKeywords: mockNegativeKeywords,
+  },
+};

--- a/src/components/Detail/KeywordBubbleMap/constants.ts
+++ b/src/components/Detail/KeywordBubbleMap/constants.ts
@@ -1,0 +1,22 @@
+export const SVG_WIDTH = 600;
+export const SVG_HEIGHT = 300;
+export const SVG_CENTER_Y = SVG_HEIGHT / 2;
+
+export const PILL_HEIGHT = 30;
+export const PILL_RADIUS = PILL_HEIGHT / 2;
+export const MAX_ORBIT = 74;
+
+export const NEWS_PILL_WIDTH = 150;
+export const NEWS_PILL_HEIGHT = 34;
+export const NEWS_PILL_RADIUS = 10;
+export const NEWS_ICON_SIZE = 14;
+export const NEWS_MAX_CHARS = 10;
+export const NEWS_ORBIT = 115;
+
+export const POS_FILL = '#FBEBF0';
+export const POS_STROKE = '#EDCACE';
+export const POS_TEXT = '#EF4444';
+
+export const NEG_FILL = '#DDF9FF';
+export const NEG_STROKE = '#A9CCFD';
+export const NEG_TEXT = '#3B82F6';

--- a/src/components/Detail/KeywordBubbleMap/index.tsx
+++ b/src/components/Detail/KeywordBubbleMap/index.tsx
@@ -157,6 +157,8 @@ export default function KeywordBubbleMap({
           return (
             <motion.g
               key={kw.keyword}
+              role="button"
+              tabIndex={isDimmed ? -1 : 0}
               animate={{
                 x: isSelected ? SVG_WIDTH / 2 - x : 0,
                 y: isSelected ? SVG_CENTER_Y - y : 0,
@@ -164,12 +166,20 @@ export default function KeywordBubbleMap({
               }}
               transition={{ duration: 0.35, ease: 'easeOut' }}
               whileHover={selected === null ? { scale: 1.08 } : {}}
+              whileFocus={selected === null ? { scale: 1.08 } : {}}
               style={{
                 transformOrigin: `${x}px ${y}px`,
                 cursor: selected === null ? 'pointer' : 'default',
               }}
               onClick={(e) => {
                 if (selected === null) {
+                  e.stopPropagation();
+                  setSelected(kw);
+                }
+              }}
+              onKeyDown={(e) => {
+                if (selected === null && (e.key === 'Enter' || e.key === ' ')) {
+                  e.preventDefault();
                   e.stopPropagation();
                   setSelected(kw);
                 }
@@ -211,6 +221,8 @@ export default function KeywordBubbleMap({
           return (
             <motion.g
               key={kw.keyword}
+              role="button"
+              tabIndex={isDimmed ? -1 : 0}
               animate={{
                 x: isSelected ? SVG_WIDTH / 2 - x : 0,
                 y: isSelected ? SVG_CENTER_Y - y : 0,
@@ -218,12 +230,20 @@ export default function KeywordBubbleMap({
               }}
               transition={{ duration: 0.35, ease: 'easeOut' }}
               whileHover={selected === null ? { scale: 1.08 } : {}}
+              whileFocus={selected === null ? { scale: 1.08 } : {}}
               style={{
                 transformOrigin: `${x}px ${y}px`,
                 cursor: selected === null ? 'pointer' : 'default',
               }}
               onClick={(e) => {
                 if (selected === null) {
+                  e.stopPropagation();
+                  setSelected(kw);
+                }
+              }}
+              onKeyDown={(e) => {
+                if (selected === null && (e.key === 'Enter' || e.key === ' ')) {
+                  e.preventDefault();
                   e.stopPropagation();
                   setSelected(kw);
                 }
@@ -267,6 +287,8 @@ export default function KeywordBubbleMap({
               return (
                 <motion.g
                   key={`news-${article.articleId}`}
+                  role="button"
+                  tabIndex={0}
                   initial={{ opacity: 0, scale: 0.75 }}
                   animate={{ opacity: 1, scale: 1 }}
                   exit={{ opacity: 0, scale: 0.75 }}
@@ -276,6 +298,7 @@ export default function KeywordBubbleMap({
                     ease: 'easeOut',
                   }}
                   whileHover={{ scale: 1.04 }}
+                  whileFocus={{ scale: 1.04 }}
                   style={{
                     cursor: 'pointer',
                     transformOrigin: `${x}px ${y}px`,
@@ -283,6 +306,13 @@ export default function KeywordBubbleMap({
                   onClick={(e) => {
                     e.stopPropagation();
                     onNewsClick(article.articleId);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      onNewsClick(article.articleId);
+                    }
                   }}
                 >
                   <rect

--- a/src/components/Detail/KeywordBubbleMap/index.tsx
+++ b/src/components/Detail/KeywordBubbleMap/index.tsx
@@ -1,0 +1,367 @@
+import { useRef, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { IoDocumentTextOutline } from 'react-icons/io5';
+import styled from 'styled-components';
+import type { KeywordsWithArticleResponse } from '@/types';
+import {
+  SVG_CENTER_Y,
+  SVG_HEIGHT,
+  SVG_WIDTH,
+  NEG_FILL,
+  NEG_STROKE,
+  NEG_TEXT,
+  NEWS_ICON_SIZE,
+  NEWS_ORBIT,
+  NEWS_PILL_HEIGHT,
+  NEWS_PILL_RADIUS,
+  NEWS_PILL_WIDTH,
+  PILL_HEIGHT,
+  PILL_RADIUS,
+  POS_FILL,
+  POS_STROKE,
+  POS_TEXT,
+} from './constants';
+import {
+  calcBubblePositions,
+  calcNewsOrbit,
+  calcNewsPositions,
+  clampOrbit,
+  pillWidth,
+  truncateTitle,
+} from './positions';
+
+type Props = {
+  positiveRatio: number;
+  negativeRatio: number;
+  positiveKeywords: KeywordsWithArticleResponse[];
+  negativeKeywords: KeywordsWithArticleResponse[];
+  onNewsClick: (articleId: string) => void;
+  date: string;
+};
+
+export default function KeywordBubbleMap({
+  positiveRatio,
+  negativeRatio,
+  positiveKeywords,
+  negativeKeywords,
+  onNewsClick,
+  date,
+}: Props) {
+  const uid = useRef(Math.random().toString(36).slice(2, 8)).current;
+  const [selected, setSelected] = useState<KeywordsWithArticleResponse | null>(
+    null
+  );
+
+  const posW = (positiveRatio / 100) * SVG_WIDTH;
+  const negW = (negativeRatio / 100) * SVG_WIDTH;
+  const posCX = posW / 2;
+  const negCX = posW + negW / 2;
+
+  const posPos = calcBubblePositions(
+    positiveKeywords.length,
+    posCX,
+    clampOrbit(posW)
+  );
+  const negPos = calcBubblePositions(
+    negativeKeywords.length,
+    negCX,
+    clampOrbit(negW)
+  );
+
+  const displayedArticles = selected?.articles.slice(0, 5) ?? [];
+  const newsOrbit = selected ? calcNewsOrbit(selected.keyword) : NEWS_ORBIT;
+  const newsPos = calcNewsPositions(displayedArticles.length, newsOrbit);
+
+  const isPos = (selected?.sentiment ?? 0) === 1;
+  const drillStroke = isPos ? POS_STROKE : NEG_STROKE;
+  const drillAccent = isPos ? POS_TEXT : NEG_TEXT;
+
+  const close = () => setSelected(null);
+
+  const posShadowId = `${uid}-sp`;
+  const negShadowId = `${uid}-sn`;
+  const newsShadowId = `${uid}-ns`;
+
+  return (
+    <Container onClick={close}>
+      <Background $ratio={positiveRatio} />
+      <DateText>{date}</DateText>
+
+      <Svg
+        viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`}
+        preserveAspectRatio="xMidYMid meet"
+        style={{ fontFamily: 'Pretendard, sans-serif' }}
+      >
+        <defs>
+          <filter id={posShadowId} x="-30%" y="-30%" width="160%" height="160%">
+            <feDropShadow
+              dx="2"
+              dy="2"
+              stdDeviation="2.5"
+              floodColor="rgba(237,202,206,0.35)"
+            />
+          </filter>
+          <filter id={negShadowId} x="-30%" y="-30%" width="160%" height="160%">
+            <feDropShadow
+              dx="2"
+              dy="2"
+              stdDeviation="2.5"
+              floodColor="rgba(169,204,253,0.35)"
+            />
+          </filter>
+
+          <filter
+            id={newsShadowId}
+            x="-20%"
+            y="-40%"
+            width="140%"
+            height="180%"
+          >
+            <feDropShadow
+              dx="0"
+              dy="3"
+              stdDeviation="5"
+              floodColor="rgba(0,0,0,0.10)"
+            />
+          </filter>
+        </defs>
+
+        <AnimatePresence>
+          {selected !== null && (
+            <motion.rect
+              key="dim"
+              x={0}
+              y={0}
+              width={SVG_WIDTH}
+              height={SVG_HEIGHT}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.3 }}
+              fill={isPos ? 'rgba(255,245,247,0.94)' : 'rgba(245,250,255,0.94)'}
+              style={{ cursor: 'default' }}
+              onClick={(e) => {
+                e.stopPropagation();
+                close();
+              }}
+            />
+          )}
+        </AnimatePresence>
+
+        {positiveKeywords.map((kw, i) => {
+          const { x, y } = posPos[i];
+          const pw = pillWidth(kw.keyword);
+          const isSelected = selected?.keyword === kw.keyword;
+          const isDimmed = selected !== null && !isSelected;
+
+          return (
+            <motion.g
+              key={kw.keyword}
+              animate={{
+                x: isSelected ? SVG_WIDTH / 2 - x : 0,
+                y: isSelected ? SVG_CENTER_Y - y : 0,
+                opacity: isDimmed ? 0 : 1,
+              }}
+              transition={{ duration: 0.35, ease: 'easeOut' }}
+              whileHover={selected === null ? { scale: 1.08 } : {}}
+              style={{
+                transformOrigin: `${x}px ${y}px`,
+                cursor: selected === null ? 'pointer' : 'default',
+              }}
+              onClick={(e) => {
+                if (selected === null) {
+                  e.stopPropagation();
+                  setSelected(kw);
+                }
+              }}
+            >
+              <rect
+                x={x - pw / 2}
+                y={y - PILL_HEIGHT / 2}
+                width={pw}
+                height={PILL_HEIGHT}
+                rx={PILL_RADIUS}
+                fill={POS_FILL}
+                stroke={POS_STROKE}
+                strokeWidth={1}
+                filter={`url(#${posShadowId})`}
+              />
+              <text
+                x={x}
+                y={y}
+                textAnchor="middle"
+                dominantBaseline="middle"
+                fontSize={13}
+                fontWeight="600"
+                fill={POS_TEXT}
+                style={{ pointerEvents: 'none' }}
+              >
+                {kw.keyword}
+              </text>
+            </motion.g>
+          );
+        })}
+
+        {negativeKeywords.map((kw, i) => {
+          const { x, y } = negPos[i];
+          const pw = pillWidth(kw.keyword);
+          const isSelected = selected?.keyword === kw.keyword;
+          const isDimmed = selected !== null && !isSelected;
+
+          return (
+            <motion.g
+              key={kw.keyword}
+              animate={{
+                x: isSelected ? SVG_WIDTH / 2 - x : 0,
+                y: isSelected ? SVG_CENTER_Y - y : 0,
+                opacity: isDimmed ? 0 : 1,
+              }}
+              transition={{ duration: 0.35, ease: 'easeOut' }}
+              whileHover={selected === null ? { scale: 1.08 } : {}}
+              style={{
+                transformOrigin: `${x}px ${y}px`,
+                cursor: selected === null ? 'pointer' : 'default',
+              }}
+              onClick={(e) => {
+                if (selected === null) {
+                  e.stopPropagation();
+                  setSelected(kw);
+                }
+              }}
+            >
+              <rect
+                x={x - pw / 2}
+                y={y - PILL_HEIGHT / 2}
+                width={pw}
+                height={PILL_HEIGHT}
+                rx={PILL_RADIUS}
+                fill={NEG_FILL}
+                stroke={NEG_STROKE}
+                strokeWidth={1}
+                filter={`url(#${negShadowId})`}
+              />
+              <text
+                x={x}
+                y={y}
+                textAnchor="middle"
+                dominantBaseline="middle"
+                fontSize={13}
+                fontWeight="600"
+                fill={NEG_TEXT}
+                style={{ pointerEvents: 'none' }}
+              >
+                {kw.keyword}
+              </text>
+            </motion.g>
+          );
+        })}
+
+        <AnimatePresence>
+          {selected !== null &&
+            displayedArticles.map((article, i) => {
+              const { x, y } = newsPos[i];
+              const title = truncateTitle(article.title);
+              const pl = x - NEWS_PILL_WIDTH / 2;
+              const pt = y - NEWS_PILL_HEIGHT / 2;
+
+              return (
+                <motion.g
+                  key={`news-${article.articleId}`}
+                  initial={{ opacity: 0, scale: 0.75 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.75 }}
+                  transition={{
+                    duration: 0.22,
+                    delay: 0.12 + i * 0.05,
+                    ease: 'easeOut',
+                  }}
+                  whileHover={{ scale: 1.04 }}
+                  style={{
+                    cursor: 'pointer',
+                    transformOrigin: `${x}px ${y}px`,
+                  }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onNewsClick(article.articleId);
+                  }}
+                >
+                  <rect
+                    x={pl}
+                    y={pt}
+                    width={NEWS_PILL_WIDTH}
+                    height={NEWS_PILL_HEIGHT}
+                    rx={NEWS_PILL_RADIUS}
+                    fill="white"
+                    stroke={drillStroke}
+                    strokeWidth={1}
+                    filter={`url(#${newsShadowId})`}
+                  />
+                  <svg
+                    x={pl + 8}
+                    y={y - NEWS_ICON_SIZE / 2}
+                    width={NEWS_ICON_SIZE}
+                    height={NEWS_ICON_SIZE}
+                    style={{ pointerEvents: 'none', overflow: 'visible' }}
+                  >
+                    <IoDocumentTextOutline
+                      width={NEWS_ICON_SIZE}
+                      height={NEWS_ICON_SIZE}
+                      color={drillAccent}
+                    />
+                  </svg>
+                  <text
+                    x={pl + 8 + NEWS_ICON_SIZE + 5}
+                    y={y + 0.5}
+                    dominantBaseline="middle"
+                    fontSize={11}
+                    fontWeight="500"
+                    fill="#374151"
+                    style={{ pointerEvents: 'none' }}
+                  >
+                    {title}
+                  </text>
+                </motion.g>
+              );
+            })}
+        </AnimatePresence>
+      </Svg>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  position: relative;
+  width: 100%;
+  aspect-ratio: 2 / 1;
+  border-radius: 16px;
+  overflow: hidden;
+  cursor: pointer;
+  user-select: none;
+`;
+
+const Background = styled.div<{ $ratio: number }>`
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to right,
+    #fff0f4 ${({ $ratio }) => Math.max(0, $ratio - 15)}%,
+    #f4f8ff ${({ $ratio }) => Math.min(100, $ratio + 15)}%
+  );
+`;
+
+const DateText = styled.span`
+  position: absolute;
+  bottom: 10px;
+  right: 14px;
+  font-size: 11px;
+  color: rgba(0, 0, 0, 0.28);
+  z-index: 1;
+  pointer-events: none;
+`;
+
+const Svg = styled.svg`
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+`;

--- a/src/components/Detail/KeywordBubbleMap/positions.ts
+++ b/src/components/Detail/KeywordBubbleMap/positions.ts
@@ -1,0 +1,102 @@
+import {
+  SVG_CENTER_Y,
+  SVG_WIDTH,
+  MAX_ORBIT,
+  NEWS_MAX_CHARS,
+  NEWS_ORBIT,
+  NEWS_PILL_HEIGHT,
+  NEWS_PILL_WIDTH,
+  PILL_HEIGHT,
+} from './constants';
+
+// count=5 공통 각도: 하단 쌍을 45°/135°로 넓혀 좌하/우하 간격 확보 (cf - 정오각형은 72° 간격)
+const ANGLES_5 = [
+  -Math.PI / 2,
+  -Math.PI / 10,
+  Math.PI / 4,
+  (3 * Math.PI) / 4,
+  (11 * Math.PI) / 10,
+];
+
+export function pillWidth(text: string): number {
+  return Math.max(56, text.length * 13 + 20);
+}
+
+export function calcBubblePositions(count: number, cx: number, orbitR: number) {
+  const angles =
+    count === 5
+      ? ANGLES_5
+      : Array.from(
+          { length: count },
+          (_, i) => ((2 * Math.PI) / Math.max(count, 1)) * i - Math.PI / 2
+        );
+  return angles.map((angle) => ({
+    x: cx + orbitR * Math.cos(angle),
+    y: SVG_CENTER_Y + orbitR * Math.sin(angle),
+  }));
+}
+
+/**
+ * 뉴스 카드 궤도 반경 동적 계산
+ * - 수평 최솟값: pill 너비/2 + gap + 뉴스 카드 너비/2 (pill과 뉴스 카드가 겹치지 않도록)
+ * - 상한: SVG 세로 경계를 벗어나지 않도록 제한
+ */
+export function calcNewsOrbit(keywordText: string): number {
+  const pw = pillWidth(keywordText);
+  const minByHoriz = pw / 2 + NEWS_PILL_WIDTH / 2 + 12;
+  const maxByBounds = SVG_CENTER_Y - NEWS_PILL_HEIGHT / 2 - 2;
+  return Math.min(maxByBounds, Math.max(NEWS_ORBIT, minByHoriz));
+}
+
+export function calcNewsPositions(count: number, orbit: number) {
+  const cx = SVG_WIDTH / 2;
+  if (count === 0) return [];
+  if (count === 1) {
+    return [{ x: cx, y: SVG_CENTER_Y + orbit * Math.sin(Math.PI / 6) }];
+  }
+  if (count === 2) {
+    const r = Math.PI / 6;
+    return [
+      { x: cx - orbit * Math.cos(r), y: SVG_CENTER_Y + orbit * Math.sin(r) },
+      { x: cx + orbit * Math.cos(r), y: SVG_CENTER_Y + orbit * Math.sin(r) },
+    ];
+  }
+  if (count === 3) {
+    const r = Math.PI / 6;
+    return [
+      { x: cx, y: SVG_CENTER_Y - orbit * Math.sin(r) },
+      { x: cx - orbit * Math.cos(r), y: SVG_CENTER_Y + orbit * Math.sin(r) },
+      { x: cx + orbit * Math.cos(r), y: SVG_CENTER_Y + orbit * Math.sin(r) },
+    ];
+  }
+  if (count === 4) {
+    return Array.from({ length: 4 }, (_, i) => {
+      const angle = -Math.PI / 4 + (Math.PI / 2) * i;
+      return {
+        x: cx + orbit * Math.cos(angle),
+        y: SVG_CENTER_Y + orbit * Math.sin(angle),
+      };
+    });
+  }
+  return ANGLES_5.map((angle) => ({
+    x: cx + orbit * Math.cos(angle),
+    y: SVG_CENTER_Y + orbit * Math.sin(angle),
+  }));
+}
+
+export function clampOrbit(sectionWidth: number): number {
+  return Math.max(
+    0,
+    Math.min(
+      MAX_ORBIT,
+      sectionWidth / 2 - PILL_HEIGHT - 8,
+      SVG_CENTER_Y - PILL_HEIGHT - 14
+    )
+  );
+}
+
+export function truncateTitle(title: string): string {
+  return title.length > NEWS_MAX_CHARS
+    ? title.slice(0, NEWS_MAX_CHARS - 1) + '…'
+    : title;
+}

--- a/src/mocks/detailHandlers.ts
+++ b/src/mocks/detailHandlers.ts
@@ -5,6 +5,7 @@ import { getRealGraphPath } from '@/api/hooks/useGetRealGraph';
 import { getRealTimePricePath } from '@/api/hooks/useGetRealTimePrice';
 import { getRealTimeStreamPath } from '@/api/hooks/useGetRealTimeStream';
 import { getArticleSummaryTickerPath } from '@/api/hooks/useGetArticleSummaryTicker';
+import { getTickerKeywordsPath } from '@/api/hooks/useGetTickerKeywords';
 import { TickerRealTimeStreamResponse } from '@/types';
 
 const mockNewsData = [
@@ -290,6 +291,104 @@ const realTimeGraphData = {
 const mockRealGraphData = generateGraphDataWithChangeRate(
   baseMockRealGraphData
 );
+
+const mockKeywordsData = [
+  {
+    keyword: '실적호조',
+    articles: [
+      { articleId: '1', title: '삼성전자 실적 호조로 주가 급등' },
+      { articleId: '2', title: '애플 신제품 출시 기대감 확산' },
+      { articleId: '3', title: 'AI 반도체 수요 폭발적 증가세' },
+    ],
+    sentiment: 1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: 'AI반도체',
+    articles: [{ articleId: '3', title: 'AI 반도체 수요 폭발적 증가세' }],
+    sentiment: 1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: '외국인매수',
+    articles: [
+      { articleId: '4', title: '코스피 외국인 순매수 전환' },
+      { articleId: '5', title: '2분기 실적 시장 기대치 상회' },
+    ],
+    sentiment: 1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: '신제품기대',
+    articles: [
+      { articleId: '2', title: '애플 신제품 출시 기대감 확산' },
+      { articleId: '1', title: '삼성전자 실적 호조로 주가 급등' },
+      { articleId: '5', title: '2분기 실적 시장 기대치 상회' },
+      { articleId: '3', title: 'AI 반도체 수요 폭발적 증가세' },
+      { articleId: '4', title: '코스피 외국인 순매수 전환' },
+    ],
+    sentiment: 1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: '어닝서프라이즈',
+    articles: [
+      { articleId: '5', title: '2분기 실적 시장 기대치 상회' },
+      { articleId: '3', title: 'AI 반도체 수요 폭발적 증가세' },
+      { articleId: '1', title: '삼성전자 실적 호조로 주가 급등' },
+      { articleId: '2', title: '애플 신제품 출시 기대감 확산' },
+    ],
+    sentiment: 1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: '금리인상',
+    articles: [
+      { articleId: '1', title: '금리 인상 우려에 증시 하락' },
+      { articleId: '5', title: '인플레이션 예상치 웃돌아' },
+      { articleId: '3', title: '달러 강세 수출주 압박' },
+    ],
+    sentiment: -1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: '중국침체',
+    articles: [
+      { articleId: '4', title: '중국 경기 침체 공포 확산' },
+      { articleId: '6', title: '반도체 공급 과잉 우려 지속' },
+    ],
+    sentiment: -1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: '달러강세',
+    articles: [
+      { articleId: '3', title: '달러 강세 수출주 압박' },
+      { articleId: '1', title: '금리 인상 우려에 증시 하락' },
+    ],
+    sentiment: -1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: '공급과잉',
+    articles: [
+      { articleId: '6', title: '반도체 공급 과잉 우려 지속' },
+      { articleId: '4', title: '중국 경기 침체 공포 확산' },
+      { articleId: '5', title: '인플레이션 예상치 웃돌아' },
+    ],
+    sentiment: -1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: '인플레이션',
+    articles: [
+      { articleId: '5', title: '인플레이션 예상치 웃돌아' },
+      { articleId: '1', title: '금리 인상 우려에 증시 하락' },
+    ],
+    sentiment: -1,
+    date: '2025-05-29',
+  },
+];
 
 const mockArticleSummary = {
   tickerId: '0-d-q-8b-95n',
@@ -759,6 +858,20 @@ export const detailHandlers = [
       },
     });
   }),
+  http.get(
+    `${BASE_URL}${getTickerKeywordsPath('0-d-q-8b-95n', '2025-05-29')}`,
+    ({ request }) => {
+      const url = new URL(request.url);
+      const date = url.searchParams.get('date') ?? '2025-05-29';
+      const keywords = mockKeywordsData.map((kw) => ({ ...kw, date }));
+
+      return HttpResponse.json({
+        code: '200 OK',
+        message: '키워드/관련 아티클 목록을 성공적으로 조회하였습니다.',
+        content: { keywords },
+      });
+    }
+  ),
   http.get(`${BASE_URL}${getArticleSummaryTickerPath('0-d-q-8b-95n')}`, () => {
     return HttpResponse.json({
       code: '200 OK',

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { useParams, useLocation } from 'react-router-dom';
+import { useParams, useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { useGetTickerDetail } from '@/api/hooks/useGetTickerDetail';
 import { useGetRealGraph, RealGraphPeriod } from '@/api/hooks/useGetRealGraph';
+import { useGetTickerKeywords } from '@/api/hooks/useGetTickerKeywords';
 import { useGetRealTimePrice } from '@/api/hooks/useGetRealTimePrice';
 import { useGetArticleSummaryTicker } from '@/api/hooks/useGetArticleSummaryTicker';
 import { useQueryClient } from '@tanstack/react-query';
@@ -21,12 +22,16 @@ import TickerHeader from '@/components/Detail/TickerHeader';
 import TickerPriceSection from '@/components/Detail/TickerPriceSection';
 import ChartSection from '@/components/Detail/ChartSection';
 import ArticleSection from '@/components/Detail/ArticleSection';
+import KeywordBubbleMap from '@/components/Detail/KeywordBubbleMap';
 
 export default function DetailPage() {
   const { id } = useParams() as { id: string };
   const location = useLocation();
+  const navigate = useNavigate();
   const isMobile = useIsMobile();
   const { isAuthenticated } = useAuth();
+
+  const today = new Date().toLocaleDateString('sv-SE');
 
   const [showSummaryModal, setShowSummaryModal] = useState(false);
   const [showLoginModal, setShowLoginModal] = useState(false);
@@ -53,12 +58,21 @@ export default function DetailPage() {
       enabled: isAuthenticated && isLiveMode,
     });
   const { data: summaryResponse } = useGetArticleSummaryTicker(id);
+  const { data: keywordsResponse } = useGetTickerKeywords(id, today);
 
   const tickerData = tickerResponse?.content;
   const realGraphData = realGraphResponse?.content;
   const realTimePriceData = realTimePriceResponse?.content;
   const summaryData = summaryResponse?.content ?? null;
   const articles = tickerData?.detailData.article;
+
+  const keywords = keywordsResponse?.content?.keywords ?? [];
+  const positiveKeywords = keywords.filter((k) => k.sentiment === 1);
+  const negativeKeywords = keywords.filter((k) => k.sentiment !== 1);
+  const total = positiveKeywords.length + negativeKeywords.length;
+  const positiveRatio =
+    total > 0 ? (positiveKeywords.length / total) * 100 : 50;
+  const negativeRatio = 100 - positiveRatio;
 
   const [isFavorite, setIsFavorite] = useState(false);
   const { mutate: putFavoriteTicker } = usePutFavoriteTicker();
@@ -180,6 +194,16 @@ export default function DetailPage() {
           onLiveMode={handleLiveMode}
           onShowSummary={() => setShowSummaryModal(true)}
         />
+        {keywords.length > 0 && (
+          <KeywordBubbleMap
+            positiveRatio={positiveRatio}
+            negativeRatio={negativeRatio}
+            positiveKeywords={positiveKeywords}
+            negativeKeywords={negativeKeywords}
+            date={today}
+            onNewsClick={(articleId) => navigate(`/news/${articleId}`)}
+          />
+        )}
         {articles && articles.length > 0 && (
           <ArticleSection
             articles={articles}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -286,3 +286,14 @@ export type TickerSearchListResponse = {
   tickerSearchList: PredictionDataResponse[];
   isMore: boolean;
 };
+
+export type KeywordsWithArticleResponse = {
+  keyword: string;
+  articles: { articleId: string; title: string }[];
+  sentiment: number;
+  date: string;
+};
+
+export type KeywordsWithArticleListResponse = {
+  keywords: KeywordsWithArticleResponse[];
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -290,7 +290,7 @@ export type TickerSearchListResponse = {
 export type KeywordsWithArticleResponse = {
   keyword: string;
   articles: { articleId: string; title: string }[];
-  sentiment: number;
+  sentiment: 1 | -1;
   date: string;
 };
 


### PR DESCRIPTION
### ✨ 작업 내용
- [x] `framer-motion` 설치 (버블 클릭 애니메이션 적용)
- [x] 긍정/부정 키워드를 버블 형태로 시각화하는 `KeywordBubbleMap` 컴포넌트 구현
  - 긍정(분홍)/부정(파랑) 영역을 배경 그라디언트로 구분
  - 버블 클릭 시 연관 뉴스 최대 5개를 orbit 형태로 펼쳐짐
  - 뉴스 클릭 시 기사 상세 페이지(`/news/:id`)로 이동
- [x] 종목 키워드/연관 뉴스 조회 API 훅 (`useGetTickerKeywords`) 추가
- [x] Detail 페이지 ChartSection 하단에 `KeywordBubbleMap` 연동
  - 오늘 날짜(로컬 기준) 기준으로 키워드 조회
  - 키워드 수 비율로 긍정/부정 영역 비율 계산
  - 키워드 데이터가 없는 경우 미노출

---

### ✨ 참고 사항
- 날짜는 `toLocaleDateString('sv-SE')`로 로컬 기준 `YYYY-MM-DD` 형식 사용 (`toISOString()`은 UTC 기준이라 자정~오전 9시 사이 오차 발생 가능)
- 키워드 데이터가 없는 경우 버블 맵 미노출 (keywords.length > 0 조건부 렌더링)

---

### ⏰ 현재 버그

---

### ✏ Git Close
