### PR TITLE
[Articker - 39] 검색 결과 문구와 KeywordBubbleMap의 키워드 관련 뉴스가 없는 경우 디자인 수정

### DIFF
--- a/src/components/Detail/KeywordBubbleMap/KeywordBubbleMap.stories.tsx
+++ b/src/components/Detail/KeywordBubbleMap/KeywordBubbleMap.stories.tsx
@@ -141,3 +141,24 @@ export const LowPositiveRatio: Story = {
     negativeKeywords: mockNegativeKeywords,
   },
 };
+
+export const WithEmptyArticles: Story = {
+  args: {
+    positiveRatio: 50,
+    negativeRatio: 50,
+    positiveKeywords: [
+      ...mockPositiveKeywords.slice(0, 3),
+      { keyword: '배당확대', articles: [], sentiment: 1, date: '2025-05-29' },
+      { keyword: '자사주매입', articles: [], sentiment: 1, date: '2025-05-29' },
+    ],
+    negativeKeywords: [
+      ...mockNegativeKeywords.slice(0, 3),
+      {
+        keyword: '규제리스크',
+        articles: [],
+        sentiment: -1,
+        date: '2025-05-29',
+      },
+    ],
+  },
+};

--- a/src/components/Detail/KeywordBubbleMap/constants.ts
+++ b/src/components/Detail/KeywordBubbleMap/constants.ts
@@ -20,3 +20,7 @@ export const POS_TEXT = '#EF4444';
 export const NEG_FILL = '#DDF9FF';
 export const NEG_STROKE = '#A9CCFD';
 export const NEG_TEXT = '#3B82F6';
+
+export const EMPTY_FILL = '#F3F4F6';
+export const EMPTY_STROKE = '#D1D5DB';
+export const EMPTY_TEXT = '#9CA3AF';

--- a/src/components/Detail/KeywordBubbleMap/index.tsx
+++ b/src/components/Detail/KeywordBubbleMap/index.tsx
@@ -10,6 +10,9 @@ import {
   NEG_FILL,
   NEG_STROKE,
   NEG_TEXT,
+  EMPTY_FILL,
+  EMPTY_STROKE,
+  EMPTY_TEXT,
   NEWS_ICON_SIZE,
   NEWS_ORBIT,
   NEWS_PILL_HEIGHT,
@@ -153,6 +156,10 @@ export default function KeywordBubbleMap({
           const pw = pillWidth(kw.keyword);
           const isSelected = selected?.keyword === kw.keyword;
           const isDimmed = selected !== null && !isSelected;
+          const hasArticles = kw.articles.length > 0;
+          const fill = hasArticles ? POS_FILL : EMPTY_FILL;
+          const stroke = hasArticles ? POS_STROKE : EMPTY_STROKE;
+          const textFill = hasArticles ? POS_TEXT : EMPTY_TEXT;
 
           return (
             <motion.g
@@ -165,20 +172,29 @@ export default function KeywordBubbleMap({
                 opacity: isDimmed ? 0 : 1,
               }}
               transition={{ duration: 0.35, ease: 'easeOut' }}
-              whileHover={selected === null ? { scale: 1.08 } : {}}
-              whileFocus={selected === null ? { scale: 1.08 } : {}}
+              whileHover={
+                selected === null && hasArticles ? { scale: 1.08 } : {}
+              }
+              whileFocus={
+                selected === null && hasArticles ? { scale: 1.08 } : {}
+              }
               style={{
                 transformOrigin: `${x}px ${y}px`,
-                cursor: selected === null ? 'pointer' : 'default',
+                cursor:
+                  selected === null && hasArticles ? 'pointer' : 'default',
               }}
               onClick={(e) => {
-                if (selected === null) {
+                if (selected === null && hasArticles) {
                   e.stopPropagation();
                   setSelected(kw);
                 }
               }}
               onKeyDown={(e) => {
-                if (selected === null && (e.key === 'Enter' || e.key === ' ')) {
+                if (
+                  selected === null &&
+                  hasArticles &&
+                  (e.key === 'Enter' || e.key === ' ')
+                ) {
                   e.preventDefault();
                   e.stopPropagation();
                   setSelected(kw);
@@ -191,8 +207,8 @@ export default function KeywordBubbleMap({
                 width={pw}
                 height={PILL_HEIGHT}
                 rx={PILL_RADIUS}
-                fill={POS_FILL}
-                stroke={POS_STROKE}
+                fill={fill}
+                stroke={stroke}
                 strokeWidth={1}
                 filter={`url(#${posShadowId})`}
               />
@@ -203,7 +219,7 @@ export default function KeywordBubbleMap({
                 dominantBaseline="middle"
                 fontSize={13}
                 fontWeight="600"
-                fill={POS_TEXT}
+                fill={textFill}
                 style={{ pointerEvents: 'none' }}
               >
                 {kw.keyword}
@@ -217,6 +233,10 @@ export default function KeywordBubbleMap({
           const pw = pillWidth(kw.keyword);
           const isSelected = selected?.keyword === kw.keyword;
           const isDimmed = selected !== null && !isSelected;
+          const hasArticles = kw.articles.length > 0;
+          const fill = hasArticles ? NEG_FILL : EMPTY_FILL;
+          const stroke = hasArticles ? NEG_STROKE : EMPTY_STROKE;
+          const textFill = hasArticles ? NEG_TEXT : EMPTY_TEXT;
 
           return (
             <motion.g
@@ -229,20 +249,29 @@ export default function KeywordBubbleMap({
                 opacity: isDimmed ? 0 : 1,
               }}
               transition={{ duration: 0.35, ease: 'easeOut' }}
-              whileHover={selected === null ? { scale: 1.08 } : {}}
-              whileFocus={selected === null ? { scale: 1.08 } : {}}
+              whileHover={
+                selected === null && hasArticles ? { scale: 1.08 } : {}
+              }
+              whileFocus={
+                selected === null && hasArticles ? { scale: 1.08 } : {}
+              }
               style={{
                 transformOrigin: `${x}px ${y}px`,
-                cursor: selected === null ? 'pointer' : 'default',
+                cursor:
+                  selected === null && hasArticles ? 'pointer' : 'default',
               }}
               onClick={(e) => {
-                if (selected === null) {
+                if (selected === null && hasArticles) {
                   e.stopPropagation();
                   setSelected(kw);
                 }
               }}
               onKeyDown={(e) => {
-                if (selected === null && (e.key === 'Enter' || e.key === ' ')) {
+                if (
+                  selected === null &&
+                  hasArticles &&
+                  (e.key === 'Enter' || e.key === ' ')
+                ) {
                   e.preventDefault();
                   e.stopPropagation();
                   setSelected(kw);
@@ -255,8 +284,8 @@ export default function KeywordBubbleMap({
                 width={pw}
                 height={PILL_HEIGHT}
                 rx={PILL_RADIUS}
-                fill={NEG_FILL}
-                stroke={NEG_STROKE}
+                fill={fill}
+                stroke={stroke}
                 strokeWidth={1}
                 filter={`url(#${negShadowId})`}
               />
@@ -267,7 +296,7 @@ export default function KeywordBubbleMap({
                 dominantBaseline="middle"
                 fontSize={13}
                 fontWeight="600"
-                fill={NEG_TEXT}
+                fill={textFill}
                 style={{ pointerEvents: 'none' }}
               >
                 {kw.keyword}

--- a/src/components/Detail/KeywordBubbleMap/index.tsx
+++ b/src/components/Detail/KeywordBubbleMap/index.tsx
@@ -182,6 +182,7 @@ export default function KeywordBubbleMap({
                 transformOrigin: `${x}px ${y}px`,
                 cursor:
                   selected === null && hasArticles ? 'pointer' : 'default',
+                outline: 'none',
               }}
               onClick={(e) => {
                 if (selected === null && hasArticles) {
@@ -259,6 +260,7 @@ export default function KeywordBubbleMap({
                 transformOrigin: `${x}px ${y}px`,
                 cursor:
                   selected === null && hasArticles ? 'pointer' : 'default',
+                outline: 'none',
               }}
               onClick={(e) => {
                 if (selected === null && hasArticles) {

--- a/src/mocks/detailHandlers.ts
+++ b/src/mocks/detailHandlers.ts
@@ -310,15 +310,6 @@ const mockKeywordsData = [
     date: '2025-05-29',
   },
   {
-    keyword: '외국인매수',
-    articles: [
-      { articleId: '4', title: '코스피 외국인 순매수 전환' },
-      { articleId: '5', title: '2분기 실적 시장 기대치 상회' },
-    ],
-    sentiment: 1,
-    date: '2025-05-29',
-  },
-  {
     keyword: '신제품기대',
     articles: [
       { articleId: '2', title: '애플 신제품 출시 기대감 확산' },
@@ -339,6 +330,11 @@ const mockKeywordsData = [
       { articleId: '2', title: '애플 신제품 출시 기대감 확산' },
     ],
     sentiment: 1,
+  },
+  {
+    keyword: '배당확대',
+    articles: [],
+    sentiment: 1,
     date: '2025-05-29',
   },
   {
@@ -347,15 +343,6 @@ const mockKeywordsData = [
       { articleId: '1', title: '금리 인상 우려에 증시 하락' },
       { articleId: '5', title: '인플레이션 예상치 웃돌아' },
       { articleId: '3', title: '달러 강세 수출주 압박' },
-    ],
-    sentiment: -1,
-    date: '2025-05-29',
-  },
-  {
-    keyword: '중국침체',
-    articles: [
-      { articleId: '4', title: '중국 경기 침체 공포 확산' },
-      { articleId: '6', title: '반도체 공급 과잉 우려 지속' },
     ],
     sentiment: -1,
     date: '2025-05-29',
@@ -385,6 +372,12 @@ const mockKeywordsData = [
       { articleId: '5', title: '인플레이션 예상치 웃돌아' },
       { articleId: '1', title: '금리 인상 우려에 증시 하락' },
     ],
+    sentiment: -1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: '규제리스크',
+    articles: [],
     sentiment: -1,
     date: '2025-05-29',
   },

--- a/src/pages/NewsBoard/index.tsx
+++ b/src/pages/NewsBoard/index.tsx
@@ -190,7 +190,7 @@ export default function NewsBoardPage() {
       {filterOption && (
         <FilterKeywordContainer>
           <Paragraph weight="normal" size="s">
-            <Text weight="bold" size="s" variant="#2d70d3">
+            <Text weight="bold" size="m" variant="#2d70d3">
               {`${filterOption} `}
             </Text>
             {josa.pick(filterOption, '으로/로')} 검색한 결과입니다.

--- a/src/pages/Ticker/index.tsx
+++ b/src/pages/Ticker/index.tsx
@@ -87,7 +87,7 @@ export default function TickerPage() {
         {filterOption && (
           <FilterKeywordContainer>
             <Paragraph weight="normal" size="s">
-              <Text weight="bold" size="s" variant="#2d70d3">
+              <Text weight="bold" size="m" variant="#2d70d3">
                 {`${filterOption} `}
               </Text>
               {josa.pick(filterOption, '으로/로')} 검색한 결과입니다.


### PR DESCRIPTION
### ✨ 작업 내용
- [x] 검색 결과 문구의 `filterOption` 글자 크기 20px으로 변경 (`size="s"` → `size="m"`)
  - 적용 페이지: `NewsBoard`, `Ticker`
- [x] 연관 뉴스가 없는 키워드 버블 색상을 회색 계열로 구분하여 표시
  - `articles.length === 0` 조건으로 별도 색상 상수 적용 (`EMPTY_FILL` / `EMPTY_STROKE` / `EMPTY_TEXT`)
  - 뉴스 없는 키워드는 hover, click, 키보드 이벤트 비활성화
- [x] `WithEmptyArticles` 스토리북 케이스 추가
- [x] 빈 기사 키워드 mock 데이터 추가 (`detailHandlers.ts`)

---

### ✨ 참고 사항
- 뉴스 없는 키워드(`articles: []`)는 클릭·hover 인터랙션이 없는 비활성 상태로 표시됨
- 색상 분기는 `constants.ts`에 `EMPTY_FILL` / `EMPTY_STROKE` / `EMPTY_TEXT` 상수로 관리
- 긍정/부정 양쪽 키워드 모두 동일한 조건으로 비활성 스타일 적용

---

### ⏰ 현재 버그

---

### ✏ Git Close