### PR TITLE
[Articker - 40] 종목 상세 페이지 API 파라미터 변경 사항 반영

### DIFF
--- a/src/api/hooks/useGetArticleSummaryTicker.ts
+++ b/src/api/hooks/useGetArticleSummaryTicker.ts
@@ -2,20 +2,20 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchInstance } from '../instance';
 import { ApiResponse, ArticleSummaryTickerResponse } from '@/types';
 
-export const getArticleSummaryTickerPath = (id: string) =>
-  `/api/v1/article-summary/${id}`;
+export const getArticleSummaryTickerPath = (id: string, date: string) =>
+  `/api/v1/article-summary/${id}?date=${date}`;
 
-export const getArticleSummaryTicker = async (id: string) => {
+export const getArticleSummaryTicker = async (id: string, date: string) => {
   const response = await fetchInstance.get<
     ApiResponse<ArticleSummaryTickerResponse>
-  >(getArticleSummaryTickerPath(id));
+  >(getArticleSummaryTickerPath(id, date));
   return response.data;
 };
 
-export const useGetArticleSummaryTicker = (id: string) => {
+export const useGetArticleSummaryTicker = (id: string, date: string) => {
   return useQuery({
-    queryKey: ['articleSummaryTicker', { id }],
-    queryFn: () => getArticleSummaryTicker(id),
+    queryKey: ['articleSummaryTicker', { id, date }],
+    queryFn: () => getArticleSummaryTicker(id, date),
     staleTime: 1000 * 60 * 5,
   });
 };

--- a/src/api/hooks/useGetTickerKeywords.ts
+++ b/src/api/hooks/useGetTickerKeywords.ts
@@ -2,20 +2,60 @@ import { useQuery } from '@tanstack/react-query';
 import type { ApiResponse, KeywordsWithArticleListResponse } from '@/types';
 import { fetchInstance } from '../instance';
 
-export const getTickerKeywordsPath = (tickerId: string, date: string) =>
-  `/api/v1/prediction/ticker/${tickerId}/keywords?date=${date}`;
+export const getTickerKeywordsPath = (
+  tickerId: string,
+  date: string,
+  keywordCount: number,
+  articleCount: number,
+  titleLength: number
+) =>
+  `/api/v1/prediction/ticker/${tickerId}/keywords?date=${date}&keywordCount=${keywordCount}&articleCount=${articleCount}&titleLength=${titleLength}`;
 
-export const getTickerKeywords = async (tickerId: string, date: string) => {
+export const getTickerKeywords = async (
+  tickerId: string,
+  date: string,
+  keywordCount: number,
+  articleCount: number,
+  titleLength: number
+) => {
   const response = await fetchInstance.get<
     ApiResponse<KeywordsWithArticleListResponse>
-  >(getTickerKeywordsPath(tickerId, date));
+  >(
+    getTickerKeywordsPath(
+      tickerId,
+      date,
+      keywordCount,
+      articleCount,
+      titleLength
+    )
+  );
   return response.data;
 };
 
-export const useGetTickerKeywords = (tickerId: string, date: string) => {
+export const useGetTickerKeywords = (
+  tickerId: string,
+  date: string,
+  keywordCount: number,
+  articleCount: number,
+  titleLength: number
+) => {
   return useQuery({
-    queryKey: ['tickerKeywords', tickerId, date],
-    queryFn: () => getTickerKeywords(tickerId, date),
+    queryKey: [
+      'tickerKeywords',
+      tickerId,
+      date,
+      keywordCount,
+      articleCount,
+      titleLength,
+    ],
+    queryFn: () =>
+      getTickerKeywords(
+        tickerId,
+        date,
+        keywordCount,
+        articleCount,
+        titleLength
+      ),
     staleTime: 1000 * 60 * 5,
   });
 };

--- a/src/mocks/detailHandlers.ts
+++ b/src/mocks/detailHandlers.ts
@@ -865,13 +865,16 @@ export const detailHandlers = [
       });
     }
   ),
-  http.get(`${BASE_URL}${getArticleSummaryTickerPath('0-d-q-8b-95n')}`, () => {
-    return HttpResponse.json({
-      code: '200 OK',
-      message: '종목 뉴스 요약 데이터 조회에 성공하였습니다.',
-      content: mockArticleSummary,
-    });
-  }),
+  http.get(
+    `${BASE_URL}${getArticleSummaryTickerPath('0-d-q-8b-95n', '2025-05-29')}`,
+    () => {
+      return HttpResponse.json({
+        code: '200 OK',
+        message: '종목 뉴스 요약 데이터 조회에 성공하였습니다.',
+        content: mockArticleSummary,
+      });
+    }
+  ),
 ];
 
 export default detailHandlers;

--- a/src/mocks/detailHandlers.ts
+++ b/src/mocks/detailHandlers.ts
@@ -852,7 +852,7 @@ export const detailHandlers = [
     });
   }),
   http.get(
-    `${BASE_URL}${getTickerKeywordsPath('0-d-q-8b-95n', '2025-05-29')}`,
+    `${BASE_URL}${getTickerKeywordsPath('0-d-q-8b-95n', '2025-05-29', 5, 5, 20)}`,
     ({ request }) => {
       const url = new URL(request.url);
       const date = url.searchParams.get('date') ?? '2025-05-29';

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -25,6 +25,11 @@ import ArticleSection from '@/components/Detail/ArticleSection';
 import KeywordBubbleMap from '@/components/Detail/KeywordBubbleMap';
 
 export default function DetailPage() {
+  // 임시 확인용 - 추후 제거 예정
+  const keywordCount = 5;
+  const articleCount = 5;
+  const titleLength = 20;
+
   const { id } = useParams() as { id: string };
   const location = useLocation();
   const navigate = useNavigate();
@@ -58,7 +63,13 @@ export default function DetailPage() {
       enabled: isAuthenticated && isLiveMode,
     });
   const { data: summaryResponse } = useGetArticleSummaryTicker(id, today);
-  const { data: keywordsResponse } = useGetTickerKeywords(id, today);
+  const { data: keywordsResponse } = useGetTickerKeywords(
+    id,
+    today,
+    keywordCount,
+    articleCount,
+    titleLength
+  );
 
   const tickerData = tickerResponse?.content;
   const realGraphData = realGraphResponse?.content;

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -57,7 +57,7 @@ export default function DetailPage() {
       tickerId: id,
       enabled: isAuthenticated && isLiveMode,
     });
-  const { data: summaryResponse } = useGetArticleSummaryTicker(id);
+  const { data: summaryResponse } = useGetArticleSummaryTicker(id, today);
   const { data: keywordsResponse } = useGetTickerKeywords(id, today);
 
   const tickerData = tickerResponse?.content;


### PR DESCRIPTION
### ✨ 작업 내용
- [x] 변경된 종목별 뉴스 요약 API의 param 옵션 반영 (`useGetArticleSummaryTicker`)
- [x] 변경된 키워드/관련 아티클 목록 API의 param 옵션 반영 (`useGetTickerKeywords`)

---

### ✨ 참고 사항

---

### ⏰ 현재 버그

---

### ✏ Git Close
