### PR TITLE
[Articker - 42] 종목 상세 페이지 그래프 API 404/500 에러 처리 개선 및 테스트 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@vitejs/plugin-react": "^4.4.1",
         "@vitest/browser-playwright": "^4.1.7",
         "@vitest/coverage-v8": "^4.1.7",
+        "axios-mock-adapter": "^2.1.0",
         "chromatic": "^17.1.0",
         "dependency-cruiser": "^16.10.4",
         "eslint": "^9.25.0",
@@ -2829,6 +2830,19 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/axios-mock-adapter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-2.1.0.tgz",
+      "integrity": "sha512-AZUe4OjECGCNNssH8SOdtneiQELsqTsat3SQQCWLPjN436/H+L9AjWfV7bF+Zg/YL9cgbhrz5671hoh+Tbn98w==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "is-buffer": "^2.0.5"
+      },
+      "peerDependencies": {
+        "axios": ">= 0.17.0"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "dev": true,
@@ -4890,6 +4904,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/is-callable": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "preview": "vite preview",
     "format": "prettier --write '**/*.{ts,tsx}'",
     "graph": "depcruise --no-config --ts-config tsconfig.json --focus",
+    "test:unit": "vitest run --project unit",
+    "test:unit:watch": "vitest --project unit",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@vitejs/plugin-react": "^4.4.1",
     "@vitest/browser-playwright": "^4.1.7",
     "@vitest/coverage-v8": "^4.1.7",
+    "axios-mock-adapter": "^2.1.0",
     "chromatic": "^17.1.0",
     "dependency-cruiser": "^16.10.4",
     "eslint": "^9.25.0",

--- a/src/api/hooks/useGetNicknameValidation.ts
+++ b/src/api/hooks/useGetNicknameValidation.ts
@@ -9,7 +9,7 @@ export const getNicknameValidationPath = (nickname: string) =>
 export const getNicknameValidation = async (nickname: string) => {
   const response = await fetchInstance.get<
     ApiResponse<NicknameValidationResponse>
-  >(getNicknameValidationPath(nickname), { withCredentials: true });
+  >(getNicknameValidationPath(nickname));
   return response.data;
 };
 

--- a/src/api/hooks/useGetRealGraph.test.ts
+++ b/src/api/hooks/useGetRealGraph.test.ts
@@ -1,0 +1,57 @@
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { fetchInstance } from '../instance';
+import { getRealGraph, getRealGraphPath } from './useGetRealGraph';
+
+describe('getRealGraph', () => {
+  let mock: MockAdapter;
+
+  beforeEach(() => {
+    mock = new MockAdapter(fetchInstance);
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  const url = `${getRealGraphPath('ticker-1')}?period=2W`;
+
+  it('200 응답 → 그래프 데이터 반환', async () => {
+    const mockData = {
+      code: '200 OK',
+      message: '실제 그래프 데이터를 성공적으로 조회하였습니다.',
+      content: {
+        period: '2W',
+        graphData: [
+          {
+            date: '2025-06-01',
+            price: 100,
+            changeRate: 0,
+            positiveArticleRatio: 0.5,
+            negativeArticleRatio: 0.5,
+          },
+        ],
+      },
+    };
+    mock.onGet(url).reply(200, mockData);
+
+    const result = await getRealGraph({ tickerId: 'ticker-1' });
+    expect(result).toEqual(mockData);
+  });
+
+  it('404 응답 → null 반환 (에러 아님)', async () => {
+    mock.onGet(url).reply(404);
+
+    const result = await getRealGraph({ tickerId: 'ticker-1' });
+    expect(result).toBeNull();
+  });
+
+  it('500 응답 → AxiosError throw', async () => {
+    mock.onGet(url).reply(500);
+
+    const error = await getRealGraph({ tickerId: 'ticker-1' }).catch((e) => e);
+    expect(axios.isAxiosError(error)).toBe(true);
+    expect(error.response?.status).toBe(500);
+  });
+});

--- a/src/api/hooks/useGetRealGraph.ts
+++ b/src/api/hooks/useGetRealGraph.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
 import { fetchInstance } from '../instance';
 
 import { ApiResponse, GraphData } from '@/types';
@@ -16,15 +17,22 @@ export const getRealGraphPath = (tickerId: string) =>
 export const getRealGraph = async ({
   tickerId,
   period = '2W',
-}: GetRealGraphParams) => {
+}: GetRealGraphParams): Promise<ApiResponse<GraphData> | null> => {
   const params = new URLSearchParams({
     period,
   });
 
-  const response = await fetchInstance.get<ApiResponse<GraphData>>(
-    `${getRealGraphPath(tickerId)}?${params}`
-  );
-  return response.data;
+  try {
+    const response = await fetchInstance.get<ApiResponse<GraphData>>(
+      `${getRealGraphPath(tickerId)}?${params}`
+    );
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 404) {
+      return null;
+    }
+    throw error;
+  }
 };
 
 export const useGetRealGraph = ({

--- a/src/api/hooks/useGetUserInfo.ts
+++ b/src/api/hooks/useGetUserInfo.ts
@@ -5,10 +5,8 @@ import { ApiResponse, UserInfoResponse } from '@/types';
 export const getUserInfoPath = () => `/api/v1/my/userinfo`;
 
 export const getUserInfo = async () => {
-  const response = await fetchInstance.get<ApiResponse<UserInfoResponse>>(
-    getUserInfoPath(),
-    { withCredentials: true }
-  );
+  const response =
+    await fetchInstance.get<ApiResponse<UserInfoResponse>>(getUserInfoPath());
   return response.data;
 };
 

--- a/src/api/hooks/usePostLogout.ts
+++ b/src/api/hooks/usePostLogout.ts
@@ -11,8 +11,7 @@ const postLogout = async ({ deviceType }: LogoutRequest) => {
     {
       deviceType,
       // refreshToken는 앱 기능 시작할 때 추가
-    },
-    { withCredentials: true }
+    }
   );
   return response.data;
 };

--- a/src/api/hooks/usePostOauthCode.ts
+++ b/src/api/hooks/usePostOauthCode.ts
@@ -14,8 +14,7 @@ const postOauthCode = async ({
     {
       authorizationCode,
       deviceType,
-    },
-    { withCredentials: true }
+    }
   );
   return response.data;
 };

--- a/src/api/hooks/usePostReissueToken.ts
+++ b/src/api/hooks/usePostReissueToken.ts
@@ -11,8 +11,7 @@ const postReissueToken = async ({ deviceType }: ReIssueRequest) => {
     {
       deviceType,
       // refreshToken는 앱 기능 시작할 때 추가
-    },
-    { withCredentials: true }
+    }
   );
   return response.data;
 };

--- a/src/api/hooks/usePutNickname.ts
+++ b/src/api/hooks/usePutNickname.ts
@@ -6,11 +6,7 @@ import { NicknameRequest } from '@/types';
 export const putNicknamePath = () => `/api/v1/my/nickname`;
 
 const putNickname = async ({ nickname }: NicknameRequest) => {
-  const response = await fetchInstance.put(
-    putNicknamePath(),
-    { nickname },
-    { withCredentials: true }
-  );
+  const response = await fetchInstance.put(putNicknamePath(), { nickname });
   return response.data;
 };
 

--- a/src/api/instance/index.test.ts
+++ b/src/api/instance/index.test.ts
@@ -28,6 +28,11 @@ describe('fetchInstance 응답 인터셉터', () => {
     await expect(fetchInstance.get('/test')).rejects.toMatchObject({
       response: { status: 401 },
     });
+    const headers = mock.history.get[0]?.headers as Record<
+      string,
+      string | undefined
+    >;
+    expect(headers?.Authorization).toBeUndefined();
     expect(mockRefresh).not.toHaveBeenCalled();
   });
 

--- a/src/api/instance/index.test.ts
+++ b/src/api/instance/index.test.ts
@@ -1,0 +1,58 @@
+import MockAdapter from 'axios-mock-adapter';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  fetchInstance,
+  setAccessToken,
+  setOnUnauthorized,
+  setRefreshTokenFn,
+} from './index';
+
+describe('fetchInstance 응답 인터셉터', () => {
+  let mock: MockAdapter;
+
+  beforeEach(() => {
+    mock = new MockAdapter(fetchInstance);
+    setAccessToken(null);
+  });
+
+  afterEach(() => {
+    mock.restore();
+    vi.clearAllMocks();
+  });
+
+  it('비로그인(accessToken 없음) 상태일 때 401 응답 받을 시 → refresh 시도 없이 401 reject', async () => {
+    const mockRefresh = vi.fn().mockResolvedValue('new-token');
+    setRefreshTokenFn(mockRefresh);
+    mock.onGet('/test').reply(401);
+
+    await expect(fetchInstance.get('/test')).rejects.toMatchObject({
+      response: { status: 401 },
+    });
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+
+  it('로그인(accessToken 있음) 상태일 때 401 응답 받을 시 → refresh 성공 → 원래 요청 재시도', async () => {
+    setAccessToken('old-token');
+    setRefreshTokenFn(vi.fn().mockResolvedValue('new-token'));
+    mock
+      .onGet('/test')
+      .replyOnce(401)
+      .onGet('/test')
+      .reply(200, { data: 'ok' });
+
+    const response = await fetchInstance.get('/test');
+    expect(response.data).toEqual({ data: 'ok' });
+  });
+
+  // isLoggingOut은 모듈 레벨 상태라 외부에서 리셋 못하니까 마지막에 배치
+  it('로그인(accessToken 있음) 상태일 때 401 응답 받을 시 → refresh 실패 → onUnauthorized 호출', async () => {
+    const onUnauthorized = vi.fn();
+    setAccessToken('old-token');
+    setRefreshTokenFn(vi.fn().mockRejectedValue(new Error('refresh 실패')));
+    setOnUnauthorized(onUnauthorized);
+    mock.onGet('/test').reply(401);
+
+    await expect(fetchInstance.get('/test')).rejects.toBeDefined();
+    expect(onUnauthorized).toHaveBeenCalledOnce();
+  });
+});

--- a/src/api/instance/index.ts
+++ b/src/api/instance/index.ts
@@ -69,7 +69,8 @@ const initInstance = (config: AxiosRequestConfig): AxiosInstance => {
         isUnauthorized &&
         !isReissueRequest &&
         !isAlreadyRetried &&
-        refreshTokenFn
+        refreshTokenFn &&
+        accessToken
       ) {
         originalRequest._retry = true;
         try {

--- a/src/components/Detail/ABTest/GroupA/ChartSection.tsx
+++ b/src/components/Detail/ABTest/GroupA/ChartSection.tsx
@@ -17,7 +17,7 @@ type ChartSectionProps = {
   period: RealGraphPeriod;
   isLiveMode: boolean;
   showRefreshTooltip: boolean;
-  realGraphData: GraphData | undefined;
+  realGraphData: GraphData;
   tickerData: TickerDetailData;
   liveChartData: TickerRealTimeGraphResponse[];
   onRefresh: () => void;
@@ -103,12 +103,10 @@ export default function ChartSection({
       {isLiveMode ? (
         <RealTimeTickerCharts realTimeData={liveChartData} />
       ) : (
-        realGraphData && (
-          <TickerCharts
-            realData={realGraphData.graphData || []}
-            sentiment={tickerData.sentiment ?? 0}
-          />
-        )
+        <TickerCharts
+          realData={realGraphData.graphData || []}
+          sentiment={tickerData.sentiment ?? 0}
+        />
       )}
     </>
   );

--- a/src/components/Detail/ABTest/GroupB/ChartSection.tsx
+++ b/src/components/Detail/ABTest/GroupB/ChartSection.tsx
@@ -16,7 +16,7 @@ type ChartSectionProps = {
   period: RealGraphPeriod;
   isLiveMode: boolean;
   showRefreshTooltip: boolean;
-  realGraphData: GraphData | undefined;
+  realGraphData: GraphData;
   tickerData: TickerDetailData;
   liveChartData: TickerRealTimeGraphResponse[];
   onRefresh: () => void;
@@ -78,12 +78,10 @@ export default function ChartSection({
       {isLiveMode ? (
         <RealTimeTickerCharts realTimeData={liveChartData} />
       ) : (
-        realGraphData && (
-          <TickerCharts
-            realData={realGraphData.graphData || []}
-            sentiment={tickerData.sentiment ?? 0}
-          />
-        )
+        <TickerCharts
+          realData={realGraphData.graphData || []}
+          sentiment={tickerData.sentiment ?? 0}
+        />
       )}
     </>
   );

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -139,7 +139,7 @@ export default function DetailPage() {
 
   const isLoading =
     tickerLoading || realGraphLoading || (isLiveMode && realTimePriceLoading);
-  const error = tickerError || realGraphError;
+  const error = tickerError;
 
   const handleRefresh = () => {
     if (isLiveMode) {
@@ -193,7 +193,6 @@ export default function DetailPage() {
     period,
     isLiveMode,
     showRefreshTooltip,
-    realGraphData,
     tickerData,
     liveChartData,
     onRefresh: handleRefresh,
@@ -231,10 +230,17 @@ export default function DetailPage() {
             />
             <TickerHeaderA {...commonHeaderProps} />
             <TickerPriceSectionA tickerData={tickerData} isMobile={isMobile} />
-            <ChartSectionA
-              {...commonChartProps}
-              onShowSummary={() => setShowSummaryModal(true)}
-            />
+            {realGraphData ? (
+              <ChartSectionA
+                {...commonChartProps}
+                realGraphData={realGraphData}
+                onShowSummary={() => setShowSummaryModal(true)}
+              />
+            ) : realGraphError ? (
+              <ErrorMessage>
+                차트 데이터를 불러오는 중 오류가 발생했습니다.
+              </ErrorMessage>
+            ) : null}
             {keywordBubbleMap}
           </>
         ) : (
@@ -243,7 +249,16 @@ export default function DetailPage() {
             <TickerPriceSectionB tickerData={tickerData} isMobile={isMobile} />
             {keywordBubbleMap}
             <DailySummary summaryData={summaryData} />
-            <ChartSectionB {...commonChartProps} />
+            {realGraphData ? (
+              <ChartSectionB
+                {...commonChartProps}
+                realGraphData={realGraphData}
+              />
+            ) : realGraphError ? (
+              <ErrorMessage>
+                차트 데이터를 불러오는 중 오류가 발생했습니다.
+              </ErrorMessage>
+            ) : null}
           </>
         )}
         {articles && articles.length > 0 && (

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,6 +25,15 @@ export default defineConfig({
     projects: [
       {
         extends: true,
+        test: {
+          name: 'unit',
+          environment: 'node',
+          globals: true,
+          include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+        },
+      },
+      {
+        extends: true,
         plugins: [
           // The plugin will run tests for the stories defined in your Storybook config
           // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest


### PR DESCRIPTION
### ✨ 작업 내용
- [x] `useGetRealGraph`에서 404 응답을 에러가 아닌 null 반환으로 처리 (`axios.isAxiosError` 활용)
- [x] 그래프 API 에러를 페이지 레벨에서 분리하여 컴포넌트 단위로 처리
  - 404: **ChartSection** 전체 숨김 (데이터 없음)
  - 500: **ChartSection** 위치에 인라인 에러 메시지 표시
- [x] **ChartSection(A/B)** `realGraphData` prop 타입 `GraphData | undefined` → `GraphData`로 좁히고 내부 불필요한 조건부 렌더링 제거
- [x] `getRealGraph` 단위 테스트 추가 (200 / 404 / 500 응답 케이스)
- [x] 코드 리뷰 반영
  - [x] 401 응답 시 헤더에 `Authorization: Bearer` null 검증 추가

---

### ✨ 참고 사항
- 기존에는 그래프 API 404 → `realGraphError` 셋팅 → `if (error) return` 분기에서 페이지 전체가 에러 화면으로 교체되는 문제 있었음
- `summaryResponse`는 이미 에러 미수집으로 처리 중이었으므로 그래프도 동일한 방향으로 통일

---

### ⏰ 현재 버그

---

### ✏ Git Close
