### PR TITLE
[Articker - 43] 종목 상세 페이지 뉴스 요약 날짜 선택 캘린더 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "fe-finn",
       "version": "0.0.0",
       "dependencies": {
+        "@daypicker/react": "^10.0.1",
         "@tanstack/react-query": "^5.80.6",
         "axios": "^1.9.0",
         "es-hangul": "^2.3.8",
@@ -472,6 +473,35 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
+      "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg=="
+    },
+    "node_modules/@daypicker/react": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@daypicker/react/-/react-10.0.1.tgz",
+      "integrity": "sha512-lH4YQz4iMBWP8hsI1bD9Eg0T7t503IkSUR/WDGGkV5mKZvwVv+ukCkJz7yN+uVFBv7vHTK+ww7a5EvlkeFwPYQ==",
+      "dependencies": {
+        "react-day-picker": "10.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emotion/is-prop-valid": {
@@ -1942,7 +1972,7 @@
     },
     "node_modules/@types/react": {
       "version": "19.1.8",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -3250,6 +3280,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -6332,6 +6371,31 @@
       "peerDependencies": {
         "apexcharts": ">=4.0.0",
         "react": ">=0.13"
+      }
+    },
+    "node_modules/react-day-picker": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-10.0.1.tgz",
+      "integrity": "sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w==",
+      "dependencies": {
+        "@date-fns/tz": "^1.4.1",
+        "date-fns": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-docgen": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@daypicker/react": "^10.0.1",
     "@tanstack/react-query": "^5.80.6",
     "axios": "^1.9.0",
     "es-hangul": "^2.3.8",

--- a/src/api/hooks/useGetArticleSummaryTicker.ts
+++ b/src/api/hooks/useGetArticleSummaryTicker.ts
@@ -12,10 +12,15 @@ export const getArticleSummaryTicker = async (id: string, date: string) => {
   return response.data;
 };
 
-export const useGetArticleSummaryTicker = (id: string, date: string) => {
+export const useGetArticleSummaryTicker = (
+  id: string,
+  date: string,
+  enabled = true
+) => {
   return useQuery({
     queryKey: ['articleSummaryTicker', { id, date }],
     queryFn: () => getArticleSummaryTicker(id, date),
     staleTime: 1000 * 60 * 5,
+    enabled,
   });
 };

--- a/src/api/hooks/useGetTickerKeywords.ts
+++ b/src/api/hooks/useGetTickerKeywords.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import type { ApiResponse, KeywordsWithArticleListResponse } from '@/types';
 import { fetchInstance } from '../instance';
 
@@ -57,5 +57,6 @@ export const useGetTickerKeywords = (
         titleLength
       ),
     staleTime: 1000 * 60 * 5,
+    placeholderData: keepPreviousData,
   });
 };

--- a/src/components/Detail/ABTest/GroupA/SummaryModal.tsx
+++ b/src/components/Detail/ABTest/GroupA/SummaryModal.tsx
@@ -37,6 +37,7 @@ export default function SummaryModal({
           <DatePickerButton
             selectedDate={selectedDate}
             onDateChange={onDateChange}
+            popupPosition="fixed"
           />
           <CloseButton onClick={onClose}>X</CloseButton>
         </HeaderActions>

--- a/src/components/Detail/ABTest/GroupA/SummaryModal.tsx
+++ b/src/components/Detail/ABTest/GroupA/SummaryModal.tsx
@@ -3,17 +3,22 @@ import { Text } from '@/components/common/typography/Text';
 import { ArticleSummaryTickerResponse } from '@/types';
 import useIsMobile from '@/hooks/useIsMobile';
 import { Paragraph } from '@/components/common/typography/Paragraph';
+import DatePickerButton from '@/components/common/DatePickerButton';
 
 type SummaryModalProps = {
   isOpen: boolean;
   onClose: () => void;
   summaryData: ArticleSummaryTickerResponse | null;
+  selectedDate: string;
+  onDateChange: (date: string) => void;
 };
 
 export default function SummaryModal({
   isOpen,
   onClose,
   summaryData,
+  selectedDate,
+  onDateChange,
 }: SummaryModalProps) {
   const isMobile = useIsMobile();
 
@@ -28,7 +33,13 @@ export default function SummaryModal({
     <>
       <Overlay onClick={onClose} />
       <ModalContainer $isMobile={isMobile}>
-        <CloseButton onClick={onClose}>X</CloseButton>
+        <HeaderActions>
+          <DatePickerButton
+            selectedDate={selectedDate}
+            onDateChange={onDateChange}
+          />
+          <CloseButton onClick={onClose}>X</CloseButton>
+        </HeaderActions>
         <ModalHeader>
           <Paragraph size={isMobile ? 's' : 'm'} weight="bold">
             {summaryData?.summaryDate && formatDate(summaryData.summaryDate)}의
@@ -183,10 +194,21 @@ const ModalContainer = styled.div<{ $isMobile: boolean }>`
   }
 `;
 
-const CloseButton = styled.button`
+const HeaderActions = styled.div`
   position: absolute;
   top: 20px;
   right: 20px;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+
+  @media screen and (max-width: 768px) {
+    top: 16px;
+    right: 16px;
+  }
+`;
+
+const CloseButton = styled.button`
   background: none;
   border: none;
   font-size: 24px;
@@ -195,8 +217,6 @@ const CloseButton = styled.button`
   padding: 4px 8px;
 
   @media screen and (max-width: 768px) {
-    top: 16px;
-    right: 16px;
     font-size: 20px;
   }
 `;

--- a/src/components/Detail/ABTest/GroupB/DailySummary.tsx
+++ b/src/components/Detail/ABTest/GroupB/DailySummary.tsx
@@ -1,14 +1,62 @@
 import styled from 'styled-components';
+import { FiFileText } from 'react-icons/fi';
+import { Paragraph } from '@/components/common/typography/Paragraph';
 import { Text } from '@/components/common/typography/Text';
+import Button from '@/components/common/Button';
 import { ArticleSummaryTickerResponse } from '@/types';
 import useIsMobile from '@/hooks/useIsMobile';
 
 export type DailySummaryProps = {
   summaryData: null | ArticleSummaryTickerResponse;
+  isEnabled: boolean;
+  isLoading: boolean;
+  onRequestSummary: () => void;
 };
 
-export default function DailySummary({ summaryData }: DailySummaryProps) {
+export default function DailySummary({
+  summaryData,
+  isEnabled,
+  isLoading,
+  onRequestSummary,
+}: DailySummaryProps) {
   const isMobile = useIsMobile();
+
+  if (!isEnabled) {
+    return (
+      <Container>
+        <PlaceholderWrapper>
+          <FiFileText size={isMobile ? 28 : 32} color="#9ca3af" />
+          <PlaceholderTextSection>
+            <Paragraph size={isMobile ? 'xs' : 's'} weight="bold">
+              오늘의 뉴스 요약
+            </Paragraph>
+            <Text size={isMobile ? 'xxs' : 'xs'} weight="normal" variant="grey">
+              AI가 분석한 긍정·부정 요인을 확인해보세요
+            </Text>
+          </PlaceholderTextSection>
+          <GenerateButton
+            variant="mint"
+            size="small"
+            onClick={onRequestSummary}
+          >
+            뉴스 요약 생성하기
+          </GenerateButton>
+        </PlaceholderWrapper>
+      </Container>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <Container>
+        <LoadingWrapper>
+          <Text size={isMobile ? 'xxs' : 'xs'} weight="normal" variant="grey">
+            요약 불러오는 중...
+          </Text>
+        </LoadingWrapper>
+      </Container>
+    );
+  }
 
   return (
     <Container>
@@ -102,6 +150,46 @@ const Container = styled.div`
     gap: 12px;
     margin-bottom: 10px;
   }
+`;
+
+const PlaceholderWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 20px 0;
+
+  @media screen and (max-width: 768px) {
+    padding: 12px 0;
+    gap: 10px;
+  }
+`;
+
+const PlaceholderTextSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  text-align: center;
+`;
+
+const GenerateButton = styled(Button)`
+  width: auto;
+  margin-top: 4px;
+  font-size: 14px;
+  padding: 0 16px;
+
+  @media screen and (max-width: 768px) {
+    padding: 0 12px;
+    font-size: 12px;
+  }
+`;
+
+const LoadingWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  padding: 20px 0;
 `;
 
 const ReasoningRow = styled.div`

--- a/src/components/Detail/ABTest/GroupB/DailySummary.tsx
+++ b/src/components/Detail/ABTest/GroupB/DailySummary.tsx
@@ -196,6 +196,18 @@ const ReasoningRow = styled.div`
   display: flex;
   gap: 20px;
   align-items: flex-start;
+  animation: fadeSlideIn 0.8s ease both;
+
+  @keyframes fadeSlideIn {
+    from {
+      opacity: 0;
+      transform: translateY(6px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
 
   @media screen and (max-width: 768px) {
     flex-direction: column;

--- a/src/components/Detail/ABTest/GroupB/DailySummary.tsx
+++ b/src/components/Detail/ABTest/GroupB/DailySummary.tsx
@@ -190,6 +190,7 @@ const LoadingWrapper = styled.div`
   display: flex;
   justify-content: center;
   padding: 20px 0;
+  min-height: 120px;
 `;
 
 const ReasoningRow = styled.div`

--- a/src/components/Detail/KeywordBubbleMap/index.tsx
+++ b/src/components/Detail/KeywordBubbleMap/index.tsx
@@ -34,6 +34,7 @@ import {
 } from './positions';
 import { Paragraph } from '@/components/common/typography/Paragraph';
 import useIsMobile from '@/hooks/useIsMobile';
+import DatePickerButton from '@/components/common/DatePickerButton';
 
 type Props = {
   positiveRatio: number;
@@ -42,6 +43,7 @@ type Props = {
   negativeKeywords: KeywordsWithArticleResponse[];
   onNewsClick: (articleId: string) => void;
   date: string;
+  onDateChange?: (date: string) => void;
 };
 
 export default function KeywordBubbleMap({
@@ -51,6 +53,7 @@ export default function KeywordBubbleMap({
   negativeKeywords,
   onNewsClick,
   date,
+  onDateChange,
 }: Props) {
   const isMobile = useIsMobile();
   const uid = useRef(Math.random().toString(36).slice(2, 8)).current;
@@ -95,9 +98,14 @@ export default function KeywordBubbleMap({
 
   return (
     <>
-      <Paragraph size={isMobile ? 'xs' : 's'} weight="bold">
-        {formatDate(date)}의 뉴스 요약
-      </Paragraph>
+      <BubbleMapHeader>
+        <Paragraph size={isMobile ? 'xs' : 's'} weight="bold">
+          {formatDate(date)}의 뉴스 요약
+        </Paragraph>
+        {onDateChange && (
+          <DatePickerButton selectedDate={date} onDateChange={onDateChange} />
+        )}
+      </BubbleMapHeader>
       <Container onClick={close}>
         <Background $ratio={positiveRatio} />
         <DateText>{date}</DateText>
@@ -416,6 +424,12 @@ export default function KeywordBubbleMap({
     </>
   );
 }
+
+const BubbleMapHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
 
 const Container = styled.div`
   position: relative;

--- a/src/components/Detail/KeywordBubbleMap/index.tsx
+++ b/src/components/Detail/KeywordBubbleMap/index.tsx
@@ -103,7 +103,11 @@ export default function KeywordBubbleMap({
           {formatDate(date)}의 뉴스 요약
         </Paragraph>
         {onDateChange && (
-          <DatePickerButton selectedDate={date} onDateChange={onDateChange} />
+          <DatePickerButton
+            selectedDate={date}
+            onDateChange={onDateChange}
+            popupZIndex={9}
+          />
         )}
       </BubbleMapHeader>
       <Container onClick={close}>

--- a/src/components/common/DatePickerButton/index.tsx
+++ b/src/components/common/DatePickerButton/index.tsx
@@ -1,40 +1,114 @@
-import { useRef } from 'react';
+import { useLayoutEffect, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { FiCalendar } from 'react-icons/fi';
+import { DayPicker } from '@daypicker/react';
+import '@daypicker/react/style.css';
 import styled from 'styled-components';
+import useClickOutside from '@/hooks/useClickOutside';
 
 type DatePickerButtonProps = {
   selectedDate: string;
   onDateChange: (date: string) => void;
+  popupZIndex?: number;
+  popupPosition?: 'fixed' | 'absolute';
 };
+
+function parseDateString(value: string): Date | undefined {
+  const [year, month, day] = value.split('-').map(Number);
+  if (!year || !month || !day) return undefined;
+  return new Date(year, month - 1, day, 12, 0, 0);
+}
+
+function formatToISODate(date: Date) {
+  return date.toLocaleDateString('sv-SE');
+}
 
 export default function DatePickerButton({
   selectedDate,
   onDateChange,
+  popupZIndex = 101,
+  popupPosition = 'absolute',
 }: DatePickerButtonProps) {
-  const inputRef = useRef<HTMLInputElement>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [popupStyle, setPopupStyle] = useState<React.CSSProperties>({});
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const popupRef = useRef<HTMLDivElement>(null);
 
-  const handleClick = () => {
-    inputRef.current?.showPicker();
+  useClickOutside(
+    [
+      wrapperRef as React.RefObject<HTMLElement>,
+      popupRef as React.RefObject<HTMLElement>,
+    ],
+    () => setIsOpen(false)
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false);
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [isOpen]);
+
+  useLayoutEffect(() => {
+    if (!isOpen || !popupRef.current || !wrapperRef.current) return;
+    const rect = wrapperRef.current.getBoundingClientRect();
+    const popupWidth = popupRef.current.offsetWidth;
+    const isFixed = popupPosition === 'fixed';
+    setPopupStyle({
+      top: rect.bottom + (isFixed ? 0 : window.scrollY) + 6,
+      left: rect.right + (isFixed ? 0 : window.scrollX) - popupWidth,
+    });
+  }, [isOpen, popupPosition]);
+
+  const handleToggle = () => setIsOpen((prev) => !prev);
+
+  const handleSelect = (selected: Date | undefined) => {
+    if (selected) {
+      onDateChange(formatToISODate(selected));
+      setIsOpen(false);
+    }
   };
 
   return (
-    <Wrapper>
-      <IconButton onClick={handleClick} type="button" aria-label="날짜 선택">
-        <FiCalendar />
-      </IconButton>
-      <HiddenInput
-        ref={inputRef}
-        type="date"
-        value={selectedDate}
-        onChange={(e) => onDateChange(e.target.value)}
-        max={new Date().toLocaleDateString('sv-SE')}
-      />
-    </Wrapper>
+    <>
+      <Wrapper ref={wrapperRef}>
+        <IconButton
+          onClick={handleToggle}
+          type="button"
+          aria-label="날짜 선택"
+          aria-expanded={isOpen}
+        >
+          <FiCalendar />
+        </IconButton>
+      </Wrapper>
+
+      {isOpen &&
+        createPortal(
+          <PopupContainer
+            ref={popupRef}
+            style={popupStyle}
+            $zIndex={popupZIndex}
+            $position={popupPosition}
+          >
+            <DayPickerWrapper>
+              <DayPicker
+                mode="single"
+                selected={parseDateString(selectedDate)}
+                onSelect={handleSelect}
+                disabled={{ after: new Date() }}
+                defaultMonth={parseDateString(selectedDate)}
+              />
+            </DayPickerWrapper>
+          </PopupContainer>,
+          document.body
+        )}
+    </>
   );
 }
 
 const Wrapper = styled.div`
-  position: relative;
   display: inline-flex;
   align-items: center;
 `;
@@ -71,9 +145,62 @@ const IconButton = styled.button`
   }
 `;
 
-const HiddenInput = styled.input`
-  position: absolute;
-  inset: 0;
-  opacity: 0;
-  pointer-events: none;
+const PopupContainer = styled.div<{
+  $zIndex: number;
+  $position: 'fixed' | 'absolute';
+}>`
+  position: ${({ $position }) => $position};
+  z-index: ${({ $zIndex }) => $zIndex};
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 2px 4px -1px rgba(0, 0, 0, 0.06),
+    0 0 0 1px rgba(0, 0, 0, 0.05);
+  overflow: hidden;
+`;
+
+const DayPickerWrapper = styled.div`
+  padding: 10px;
+
+  .rdp-root {
+    --rdp-accent-color: #0057ff;
+    --rdp-accent-background-color: #e8f0ff;
+    --rdp-today-color: #0057ff;
+    --rdp-day-height: 36px;
+    --rdp-day-width: 36px;
+    --rdp-day_button-height: 34px;
+    --rdp-day_button-width: 34px;
+    --rdp-day_button-border-radius: 6px;
+  }
+
+  .rdp-selected .rdp-day_button {
+    background-color: #0057ff;
+    color: #ffffff;
+    font-weight: 700;
+    border-color: transparent;
+  }
+
+  .rdp-day:not(.rdp-selected):not(.rdp-disabled) .rdp-day_button:hover {
+    background-color: #e8f0ff;
+    color: #0057ff;
+  }
+
+  .rdp-month_caption,
+  .rdp-caption_label {
+    font-weight: 700;
+    color: #374151;
+    font-size: 14px;
+  }
+
+  .rdp-weekday {
+    color: #6b7280;
+    font-size: 12px;
+    font-weight: 600;
+  }
+
+  .rdp-day_button {
+    font-size: 13px;
+    color: #374151;
+  }
 `;

--- a/src/components/common/DatePickerButton/index.tsx
+++ b/src/components/common/DatePickerButton/index.tsx
@@ -1,0 +1,79 @@
+import { useRef } from 'react';
+import { FiCalendar } from 'react-icons/fi';
+import styled from 'styled-components';
+
+type DatePickerButtonProps = {
+  selectedDate: string;
+  onDateChange: (date: string) => void;
+};
+
+export default function DatePickerButton({
+  selectedDate,
+  onDateChange,
+}: DatePickerButtonProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleClick = () => {
+    inputRef.current?.showPicker();
+  };
+
+  return (
+    <Wrapper>
+      <IconButton onClick={handleClick} type="button" aria-label="날짜 선택">
+        <FiCalendar />
+      </IconButton>
+      <HiddenInput
+        ref={inputRef}
+        type="date"
+        value={selectedDate}
+        onChange={(e) => onDateChange(e.target.value)}
+        max={new Date().toLocaleDateString('sv-SE')}
+      />
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+`;
+
+const IconButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  color: #6b7280;
+  border-radius: 4px;
+  transition:
+    color 0.15s,
+    background-color 0.15s;
+
+  &:hover {
+    color: #374151;
+    background-color: #f3f4f6;
+  }
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
+
+  @media screen and (max-width: 768px) {
+    svg {
+      width: 14px;
+      height: 14px;
+    }
+  }
+`;
+
+const HiddenInput = styled.input`
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  pointer-events: none;
+`;

--- a/src/components/common/DatePickerButton/index.tsx
+++ b/src/components/common/DatePickerButton/index.tsx
@@ -34,13 +34,7 @@ export default function DatePickerButton({
   const wrapperRef = useRef<HTMLDivElement>(null);
   const popupRef = useRef<HTMLDivElement>(null);
 
-  useClickOutside(
-    [
-      wrapperRef as React.RefObject<HTMLElement>,
-      popupRef as React.RefObject<HTMLElement>,
-    ],
-    () => setIsOpen(false)
-  );
+  useClickOutside([wrapperRef, popupRef], () => setIsOpen(false));
 
   useEffect(() => {
     if (!isOpen) return;

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -51,6 +51,7 @@ export default function DetailPage() {
   const [selectedDate, setSelectedDate] = useState(today);
   const [showSummaryModal, setShowSummaryModal] = useState(false);
   const [showLoginModal, setShowLoginModal] = useState(false);
+  const [summaryEnabled, setSummaryEnabled] = useState(false);
 
   const [period, setPeriod] = useState<RealGraphPeriod>('2W');
   const [isLiveMode, setIsLiveMode] = useState(false);
@@ -73,10 +74,19 @@ export default function DetailPage() {
       tickerId: id,
       enabled: isAuthenticated && isLiveMode,
     });
-  const { data: summaryResponse } = useGetArticleSummaryTicker(
-    id,
-    selectedDate
-  );
+  const { data: summaryResponse, isLoading: summaryLoading } =
+    useGetArticleSummaryTicker(
+      id,
+      selectedDate,
+      variant === 'A' || (summaryEnabled && isAuthenticated)
+    );
+
+  const handleRequestSummary = () => {
+    if (!isAuthenticated) {
+      setShowLoginModal(true);
+    }
+    setSummaryEnabled(true);
+  };
   const { data: keywordsResponse } = useGetTickerKeywords(
     id,
     today,
@@ -242,7 +252,13 @@ export default function DetailPage() {
               <ChartSectionA
                 {...commonChartProps}
                 realGraphData={realGraphData}
-                onShowSummary={() => setShowSummaryModal(true)}
+                onShowSummary={() => {
+                  if (!isAuthenticated) {
+                    setShowLoginModal(true);
+                    return;
+                  }
+                  setShowSummaryModal(true);
+                }}
               />
             ) : realGraphError ? (
               <ErrorMessage>
@@ -256,7 +272,12 @@ export default function DetailPage() {
             <TickerHeaderB {...commonHeaderProps} />
             <TickerPriceSectionB tickerData={tickerData} isMobile={isMobile} />
             {keywordBubbleMap('B')}
-            <DailySummary summaryData={summaryData} />
+            <DailySummary
+              summaryData={summaryData}
+              isEnabled={summaryEnabled && isAuthenticated}
+              isLoading={summaryLoading}
+              onRequestSummary={handleRequestSummary}
+            />
             {realGraphData ? (
               <ChartSectionB
                 {...commonChartProps}

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -89,7 +89,7 @@ export default function DetailPage() {
   };
   const { data: keywordsResponse } = useGetTickerKeywords(
     id,
-    today,
+    selectedDate,
     keywordCount,
     articleCount,
     titleLength
@@ -228,7 +228,7 @@ export default function DetailPage() {
         negativeRatio={negativeRatio}
         positiveKeywords={positiveKeywords}
         negativeKeywords={negativeKeywords}
-        date={today}
+        date={selectedDate}
         onNewsClick={(articleId) => navigate(`/news/${articleId}`)}
         {...(variant === 'B' && { onDateChange: setSelectedDate })}
       />

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -48,6 +48,7 @@ export default function DetailPage() {
 
   const today = new Date().toLocaleDateString('sv-SE');
 
+  const [selectedDate, setSelectedDate] = useState(today);
   const [showSummaryModal, setShowSummaryModal] = useState(false);
   const [showLoginModal, setShowLoginModal] = useState(false);
 
@@ -72,7 +73,10 @@ export default function DetailPage() {
       tickerId: id,
       enabled: isAuthenticated && isLiveMode,
     });
-  const { data: summaryResponse } = useGetArticleSummaryTicker(id, today);
+  const { data: summaryResponse } = useGetArticleSummaryTicker(
+    id,
+    selectedDate
+  );
   const { data: keywordsResponse } = useGetTickerKeywords(
     id,
     today,
@@ -207,16 +211,18 @@ export default function DetailPage() {
     onLikeClick: handleLikeClick,
   };
 
-  const keywordBubbleMap = keywords.length > 0 && (
-    <KeywordBubbleMap
-      positiveRatio={positiveRatio}
-      negativeRatio={negativeRatio}
-      positiveKeywords={positiveKeywords}
-      negativeKeywords={negativeKeywords}
-      date={today}
-      onNewsClick={(articleId) => navigate(`/news/${articleId}`)}
-    />
-  );
+  const keywordBubbleMap = (variant: 'A' | 'B') =>
+    keywords.length > 0 && (
+      <KeywordBubbleMap
+        positiveRatio={positiveRatio}
+        negativeRatio={negativeRatio}
+        positiveKeywords={positiveKeywords}
+        negativeKeywords={negativeKeywords}
+        date={today}
+        onNewsClick={(articleId) => navigate(`/news/${articleId}`)}
+        {...(variant === 'B' && { onDateChange: setSelectedDate })}
+      />
+    );
 
   return (
     <>
@@ -227,6 +233,8 @@ export default function DetailPage() {
               isOpen={showSummaryModal}
               onClose={() => setShowSummaryModal(false)}
               summaryData={summaryData}
+              selectedDate={selectedDate}
+              onDateChange={setSelectedDate}
             />
             <TickerHeaderA {...commonHeaderProps} />
             <TickerPriceSectionA tickerData={tickerData} isMobile={isMobile} />
@@ -241,13 +249,13 @@ export default function DetailPage() {
                 차트 데이터를 불러오는 중 오류가 발생했습니다.
               </ErrorMessage>
             ) : null}
-            {keywordBubbleMap}
+            {keywordBubbleMap('A')}
           </>
         ) : (
           <>
             <TickerHeaderB {...commonHeaderProps} />
             <TickerPriceSectionB tickerData={tickerData} isMobile={isMobile} />
-            {keywordBubbleMap}
+            {keywordBubbleMap('B')}
             <DailySummary summaryData={summaryData} />
             {realGraphData ? (
               <ChartSectionB


### PR DESCRIPTION
### ✨ 작업 내용
- [x] `DatePickerButton` 컴포넌트 추가 (react-day-picker 기반 커스텀 캘린더 팝업)
- [x] A/B 버전 각각에 날짜 선택 기능 연동
  - B버전: KeywordBubbleMap 헤더에 DatePickerButton 노출, 날짜 변경 시 뉴스 요약 API 재호출
  - A버전: SummaryModal 내 DatePickerButton (`popupPosition: fixed`)
- [x] B버전 DailySummary CTA 진입점 추가 및 A버전 로그인 인증 검사 추가
- [x] DailySummary 로딩 상태 UX 개선
  - 로딩 중 `min-height` 적용으로 레이아웃 시프트 완화
  - 데이터 진입 시 `fadeSlideIn` 애니메이션 추가
- [x] DatePicker 날짜 변경 시 KeywordBubbleMap API도 함께 갱신되도록 수정
- [x] 코드 리뷰 반영
  - DatePickerButton의 `useClickOutside`에서 불필요한 타입 캐스팅 제거

---

### ✨ 참고 사항
- 날짜 선택 UI 방식 변경
  - 1차 시도: 네이티브 `<input type="date">` 사용
    -> 브라우저 기본 캘린더 UI는 스타일링이 불가해 디자인 일관성 유지 어려움
  - 2차 시도: react-day-picker 기반 커스텀 팝업 캘린더로 교체

- KeywordBubbleMap 날짜 연동
  - 1차 시도: `useGetTickerKeywords`에 `today`(고정값) 전달 → 날짜 변경 시 버블맵 API 미갱신
    -> refetch 중 `keywords`가 빈 배열이 되어 컴포넌트가 언마운트되며 흰 화면 발생
  - 2차 시도: `selectedDate` 전달 + `placeholderData: keepPreviousData` 추가 → refetch 중 이전 데이터 유지로 흰 화면 방지

- `useClickOutside`가 현재 `React.RefObject<HTMLElement>`로 캐스팅이 필요한 구조 → 추후 제네릭(`<T extends HTMLElement>`)으로 수정해 캐스팅 없이 사용 가능하도록 개선 고려

---

### ⏰ 현재 버그

---

### ✏ Git Close
