### PR TITLE
[Articker - 44] 종목 상세 페이지 SummaryModal 캘린더 UI 개선

### DIFF
--- a/src/components/Detail/ABTest/GroupA/SummaryModal.tsx
+++ b/src/components/Detail/ABTest/GroupA/SummaryModal.tsx
@@ -43,8 +43,7 @@ export default function SummaryModal({
         </HeaderActions>
         <ModalHeader>
           <Paragraph size={isMobile ? 's' : 'm'} weight="bold">
-            {summaryData?.summaryDate && formatDate(summaryData.summaryDate)}의
-            뉴스 요약
+            {formatDate(selectedDate)}의 뉴스 요약
           </Paragraph>
         </ModalHeader>
         <ModalContent>

--- a/src/components/Detail/ABTest/GroupA/SummaryModal.tsx
+++ b/src/components/Detail/ABTest/GroupA/SummaryModal.tsx
@@ -4,6 +4,7 @@ import { ArticleSummaryTickerResponse } from '@/types';
 import useIsMobile from '@/hooks/useIsMobile';
 import { Paragraph } from '@/components/common/typography/Paragraph';
 import DatePickerButton from '@/components/common/DatePickerButton';
+import { formatMonthDay } from '@/utils/formatDate';
 
 type SummaryModalProps = {
   isOpen: boolean;
@@ -24,11 +25,6 @@ export default function SummaryModal({
 
   if (!isOpen) return null;
 
-  const formatDate = (dateString: string) => {
-    const [, month, day] = dateString.split('-');
-    return `${Number(month)}월 ${Number(day)}일`;
-  };
-
   return (
     <>
       <Overlay onClick={onClose} />
@@ -44,7 +40,7 @@ export default function SummaryModal({
         </HeaderActions>
         <ModalHeader>
           <Paragraph size={isMobile ? 's' : 'm'} weight="bold">
-            {formatDate(selectedDate)}의 뉴스 요약
+            {formatMonthDay(selectedDate)}의 뉴스 요약
           </Paragraph>
         </ModalHeader>
         <ModalContent>

--- a/src/components/Detail/ABTest/GroupA/SummaryModal.tsx
+++ b/src/components/Detail/ABTest/GroupA/SummaryModal.tsx
@@ -38,6 +38,7 @@ export default function SummaryModal({
             selectedDate={selectedDate}
             onDateChange={onDateChange}
             popupPosition="fixed"
+            popupAlign="right"
           />
           <CloseButton onClick={onClose}>X</CloseButton>
         </HeaderActions>

--- a/src/components/Detail/KeywordBubbleMap/index.tsx
+++ b/src/components/Detail/KeywordBubbleMap/index.tsx
@@ -434,6 +434,7 @@ export default function KeywordBubbleMap({
 }
 
 const BubbleMapHeader = styled.div`
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: flex-start;

--- a/src/components/Detail/KeywordBubbleMap/index.tsx
+++ b/src/components/Detail/KeywordBubbleMap/index.tsx
@@ -36,6 +36,7 @@ import { Paragraph } from '@/components/common/typography/Paragraph';
 import { Text } from '@/components/common/typography/Text';
 import useIsMobile from '@/hooks/useIsMobile';
 import DatePickerButton from '@/components/common/DatePickerButton';
+import { formatMonthDay } from '@/utils/formatDate';
 
 type Props = {
   positiveRatio: number;
@@ -92,17 +93,12 @@ export default function KeywordBubbleMap({
   const negShadowId = `${uid}-sn`;
   const newsShadowId = `${uid}-ns`;
 
-  const formatDate = (dateString: string) => {
-    const [, month, day] = dateString.split('-');
-    return `${Number(month)}월 ${Number(day)}일`;
-  };
-
   return (
     <>
       <BubbleMapHeader>
         <Paragraph size={isMobile ? 'xs' : 's'} weight="bold">
           <Text size={isMobile ? 'xs' : 's'} weight="bold" variant="#2d70d3">
-            {formatDate(date)}
+            {formatMonthDay(date)}
           </Text>
           의 뉴스 요약
         </Paragraph>

--- a/src/components/Detail/KeywordBubbleMap/index.tsx
+++ b/src/components/Detail/KeywordBubbleMap/index.tsx
@@ -436,7 +436,8 @@ export default function KeywordBubbleMap({
 const BubbleMapHeader = styled.div`
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
+  gap: 6px;
 `;
 
 const Container = styled.div`

--- a/src/components/Detail/KeywordBubbleMap/index.tsx
+++ b/src/components/Detail/KeywordBubbleMap/index.tsx
@@ -33,6 +33,7 @@ import {
   truncateTitle,
 } from './positions';
 import { Paragraph } from '@/components/common/typography/Paragraph';
+import { Text } from '@/components/common/typography/Text';
 import useIsMobile from '@/hooks/useIsMobile';
 import DatePickerButton from '@/components/common/DatePickerButton';
 
@@ -100,7 +101,10 @@ export default function KeywordBubbleMap({
     <>
       <BubbleMapHeader>
         <Paragraph size={isMobile ? 'xs' : 's'} weight="bold">
-          {formatDate(date)}의 뉴스 요약
+          <Text size={isMobile ? 'xs' : 's'} weight="bold" variant="#2d70d3">
+            {formatDate(date)}
+          </Text>
+          의 뉴스 요약
         </Paragraph>
         {onDateChange && (
           <DatePickerButton

--- a/src/components/common/DatePickerButton/index.tsx
+++ b/src/components/common/DatePickerButton/index.tsx
@@ -114,7 +114,7 @@ const IconButton = styled.button`
   background: none;
   border: none;
   cursor: pointer;
-  padding: 4px;
+  padding: 0 0 4px 0;
   color: #6b7280;
   border-radius: 4px;
   transition:
@@ -127,14 +127,15 @@ const IconButton = styled.button`
   }
 
   svg {
-    width: 16px;
-    height: 16px;
+    width: 18px;
+    height: 18px;
   }
 
   @media screen and (max-width: 768px) {
+    padding: 0 0 2px 0;
     svg {
-      width: 14px;
-      height: 14px;
+      width: 16px;
+      height: 16px;
     }
   }
 `;

--- a/src/components/common/DatePickerButton/index.tsx
+++ b/src/components/common/DatePickerButton/index.tsx
@@ -91,7 +91,7 @@ export default function DatePickerButton({
                 mode="single"
                 selected={parseDateString(selectedDate)}
                 onSelect={handleSelect}
-                disabled={{ after: new Date() }}
+                disabled={{ before: new Date(2026, 5, 1), after: new Date() }}
                 defaultMonth={parseDateString(selectedDate)}
               />
             </DayPickerWrapper>

--- a/src/components/common/DatePickerButton/index.tsx
+++ b/src/components/common/DatePickerButton/index.tsx
@@ -11,6 +11,7 @@ type DatePickerButtonProps = {
   onDateChange: (date: string) => void;
   popupZIndex?: number;
   popupPosition?: 'fixed' | 'absolute';
+  popupAlign?: 'left' | 'right';
 };
 
 function parseDateString(value: string): Date | undefined {
@@ -28,13 +29,14 @@ export default function DatePickerButton({
   onDateChange,
   popupZIndex = 101,
   popupPosition = 'absolute',
+  popupAlign = 'left',
 }: DatePickerButtonProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const [popupStyle, setPopupStyle] = useState<React.CSSProperties>({});
+  const [fixedStyle, setFixedStyle] = useState<React.CSSProperties>({});
   const wrapperRef = useRef<HTMLDivElement>(null);
-  const popupRef = useRef<HTMLDivElement>(null);
+  const fixedPopupRef = useRef<HTMLDivElement>(null);
 
-  useClickOutside([wrapperRef, popupRef], () => setIsOpen(false));
+  useClickOutside([wrapperRef, fixedPopupRef], () => setIsOpen(false));
 
   useEffect(() => {
     if (!isOpen) return;
@@ -46,15 +48,18 @@ export default function DatePickerButton({
   }, [isOpen]);
 
   useLayoutEffect(() => {
-    if (!isOpen || !popupRef.current || !wrapperRef.current) return;
+    if (popupPosition !== 'fixed' || !isOpen || !wrapperRef.current) return;
     const rect = wrapperRef.current.getBoundingClientRect();
-    const popupWidth = popupRef.current.offsetWidth;
-    const isFixed = popupPosition === 'fixed';
-    setPopupStyle({
-      top: rect.bottom + (isFixed ? 0 : window.scrollY) + 6,
-      left: rect.right + (isFixed ? 0 : window.scrollX) - popupWidth,
-    });
-  }, [isOpen, popupPosition]);
+    if (popupAlign === 'right') {
+      setFixedStyle({
+        top: rect.bottom + 6,
+        left: rect.right,
+        transform: 'translateX(-100%)',
+      });
+    } else {
+      setFixedStyle({ top: rect.bottom + 6, left: rect.left });
+    }
+  }, [isOpen, popupPosition, popupAlign]);
 
   const handleToggle = () => setIsOpen((prev) => !prev);
 
@@ -65,40 +70,48 @@ export default function DatePickerButton({
     }
   };
 
+  const dayPicker = (
+    <DayPickerWrapper>
+      <DayPicker
+        mode="single"
+        selected={parseDateString(selectedDate)}
+        onSelect={handleSelect}
+        disabled={{ before: new Date(2026, 5, 1), after: new Date() }}
+        defaultMonth={parseDateString(selectedDate)}
+      />
+    </DayPickerWrapper>
+  );
+
   return (
-    <>
-      <Wrapper ref={wrapperRef}>
-        <IconButton
-          onClick={handleToggle}
-          type="button"
-          aria-label="날짜 선택"
-          aria-expanded={isOpen}
-        >
-          <FiCalendar />
-        </IconButton>
-      </Wrapper>
+    <Wrapper ref={wrapperRef}>
+      <IconButton
+        onClick={handleToggle}
+        type="button"
+        aria-label="날짜 선택"
+        aria-expanded={isOpen}
+      >
+        <FiCalendar />
+      </IconButton>
+
+      {isOpen && popupPosition === 'absolute' && (
+        <AbsolutePopup $zIndex={popupZIndex} $align={popupAlign}>
+          {dayPicker}
+        </AbsolutePopup>
+      )}
 
       {isOpen &&
+        popupPosition === 'fixed' &&
         createPortal(
-          <PopupContainer
-            ref={popupRef}
-            style={popupStyle}
+          <FixedPopup
+            ref={fixedPopupRef}
+            style={fixedStyle}
             $zIndex={popupZIndex}
-            $position={popupPosition}
           >
-            <DayPickerWrapper>
-              <DayPicker
-                mode="single"
-                selected={parseDateString(selectedDate)}
-                onSelect={handleSelect}
-                disabled={{ before: new Date(2026, 5, 1), after: new Date() }}
-                defaultMonth={parseDateString(selectedDate)}
-              />
-            </DayPickerWrapper>
-          </PopupContainer>,
+            {dayPicker}
+          </FixedPopup>,
           document.body
         )}
-    </>
+    </Wrapper>
   );
 }
 
@@ -140,11 +153,7 @@ const IconButton = styled.button`
   }
 `;
 
-const PopupContainer = styled.div<{
-  $zIndex: number;
-  $position: 'fixed' | 'absolute';
-}>`
-  position: ${({ $position }) => $position};
+const PopupBase = styled.div<{ $zIndex: number }>`
   z-index: ${({ $zIndex }) => $zIndex};
   background: #ffffff;
   border-radius: 12px;
@@ -153,6 +162,16 @@ const PopupContainer = styled.div<{
     0 2px 4px -1px rgba(0, 0, 0, 0.06),
     0 0 0 1px rgba(0, 0, 0, 0.05);
   overflow: hidden;
+`;
+
+const AbsolutePopup = styled(PopupBase)<{ $align: 'left' | 'right' }>`
+  position: absolute;
+  top: calc(100% + 6px);
+  ${({ $align }) => ($align === 'right' ? 'right: 0;' : 'left: 0;')}
+`;
+
+const FixedPopup = styled(PopupBase)`
+  position: fixed;
 `;
 
 const DayPickerWrapper = styled.div`

--- a/src/components/common/DatePickerButton/index.tsx
+++ b/src/components/common/DatePickerButton/index.tsx
@@ -35,6 +35,7 @@ export default function DatePickerButton({
   const [fixedStyle, setFixedStyle] = useState<React.CSSProperties>({});
   const wrapperRef = useRef<HTMLDivElement>(null);
   const fixedPopupRef = useRef<HTMLDivElement>(null);
+  const MIN_SELECTABLE_DATE = new Date(2026, 5, 1);
 
   useClickOutside([wrapperRef, fixedPopupRef], () => setIsOpen(false));
 
@@ -76,7 +77,7 @@ export default function DatePickerButton({
         mode="single"
         selected={parseDateString(selectedDate)}
         onSelect={handleSelect}
-        disabled={{ before: new Date(2026, 5, 1), after: new Date() }}
+        disabled={{ before: MIN_SELECTABLE_DATE, after: new Date() }}
         defaultMonth={parseDateString(selectedDate)}
       />
     </DayPickerWrapper>

--- a/src/mocks/myPageHandler.ts
+++ b/src/mocks/myPageHandler.ts
@@ -91,7 +91,7 @@ export const mockFavoriteTickers = mockTickerData.slice(0, 5).map((item) => {
       ];
 
   return {
-    tickerId: crypto.randomUUID(),
+    tickerId: Math.random().toString(36).slice(2),
     ...item,
     graphData: { isMarketOpen, priceData },
   };

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,4 @@
+export function formatMonthDay(dateString: string): string {
+  const [, month, day] = dateString.split('-');
+  return `${Number(month)}월 ${Number(day)}일`;
+}


### PR DESCRIPTION
### ✨ 작업 내용
- [x] SummaryModal 데이터 없을 때 날짜 사라지는 버그 수정
- [x] 6월 1일 이전 캘린더 날짜 접근 차단
- [x] SummaryHeader 날짜 강조를 위한 색상 변경
- [x] mock 핸들러 tickerId 생성 방식을 `Math.random()`으로 변경
  - http IP 접속 환경에서 `crypto.randomUUID()`가 동작하지 않아 모바일뷰 확인 못한 오류 해결
- [x] DatePickerButton 위치 및 크기 스타일 조정
- [x] DatePickerButton에 `popupAlign` prop 추가 (A/B 공통 적용)
  - `left`(기본값): **B버전** KeywordBubbleMap 기존 동작 유지
  - `right`: **A버전** SummaryModal처럼 우측 배치 아이콘에서 왼쪽 방향으로 팝업이 열리는 경우에 사용
- [x] DatePickerButton 팝업 렌더링 분기 리팩터링
  - `absolute` / `fixed` 각각을 `AbsolutePopup` / `FixedPopup` 별도 컴포넌트로 분리
- [x] **A버전** SummaryModal DatePicker에 `popupAlign="right"` 적용
- [x] **B버전** KeywordBubbleMap `BubbleMapHeader`에 `position: relative` 추가
- 코드 리뷰 반영
  - [x] DatePickerButton 선택 가능 시작일을 상수로 분리
  - [x] formatDate 구현 중복 제거 및 공통 유틸로 추출


---

### ✨ 참고 사항
- `popupAlign="right"` 구현 방식
  - 1차 시도: `right: window.innerWidth - rect.right` CSS right 속성 사용
    → 스크롤바 너비 등 뷰포트 너비 불일치로 미세 오차 발생
  - 2차 시도: `left: rect.right + transform: translateX(-100%)` 방식으로 변경
    → 팝업 자체 너비 기준으로 이동하므로 아이콘 오른쪽 끝에 정확히 정렬됨

---

### ⏰ 현재 버그

---

### ✏ Git Close
