### PR TITLE
[Articker - 45] 종목 상세 페이지 KeywordBubbleMap UI 겹치는 문제 및 여백 수정

### DIFF
--- a/src/components/Detail/KeywordBubbleMap/KeywordBubbleMap.stories.tsx
+++ b/src/components/Detail/KeywordBubbleMap/KeywordBubbleMap.stories.tsx
@@ -163,6 +163,48 @@ export const WithEmptyArticles: Story = {
   },
 };
 
+export const NewsCount2: Story = {
+  args: {
+    positiveRatio: 60,
+    negativeRatio: 40,
+    positiveKeywords: [
+      {
+        keyword: '어닝서프라이즈',
+        articles: [
+          {
+            articleId: 'a1',
+            title: '삼성전자 실적 호조로 주가 급등 추세 보여',
+          },
+          {
+            articleId: 'a2',
+            title: '마이크로소프트 스탁 온 더 딥을 사야 한다',
+          },
+        ],
+        sentiment: 1,
+        date: '2025-05-29',
+      },
+    ],
+    negativeKeywords: [
+      {
+        keyword: '금리인상우려',
+        articles: [
+          {
+            articleId: 'b1',
+            title: '삼성전자 실적 호조로 주가 급등 추세 보여',
+          },
+          {
+            articleId: 'b2',
+            title: '삼성전자 실적 호조로 주가 급등 추세 보여',
+          },
+        ],
+        sentiment: -1,
+        date: '2025-05-29',
+      },
+    ],
+    date: '2025-05-29',
+  },
+};
+
 export const EmptyKeywords: Story = {
   args: {
     positiveRatio: 50,

--- a/src/components/Detail/KeywordBubbleMap/KeywordBubbleMap.stories.tsx
+++ b/src/components/Detail/KeywordBubbleMap/KeywordBubbleMap.stories.tsx
@@ -205,6 +205,40 @@ export const NewsCount2: Story = {
   },
 };
 
+export const MixedLanguageNews: Story = {
+  args: {
+    positiveRatio: 50,
+    negativeRatio: 50,
+    positiveKeywords: [
+      {
+        keyword: 'AI인프라',
+        articles: [
+          { articleId: 'a1', title: 'Dell Technologies의 레거시 전환' },
+          { articleId: 'a2', title: '이 에너지 주식은 AI의 가장 큰 수혜주' },
+          { articleId: 'a3', title: 'Nvidia의 2027년 매출 전망 상향' },
+          { articleId: 'a4', title: '삼성전자 AI반도체 공급 계약 체결' },
+          { articleId: 'a5', title: 'ServiceNow와 Salesforce 협업 발표' },
+        ],
+        sentiment: 1,
+        date: '2025-05-29',
+      },
+    ],
+    negativeKeywords: [
+      {
+        keyword: '규제리스크',
+        articles: [
+          { articleId: 'b1', title: 'EU AI Act 규제 강화로 빅테크 압박' },
+          { articleId: 'b2', title: 'Microsoft vs Google antitrust 소송' },
+          { articleId: 'b3', title: '반도체 수출 규제 확대 우려 증가세' },
+        ],
+        sentiment: -1,
+        date: '2025-05-29',
+      },
+    ],
+    date: '2025-05-29',
+  },
+};
+
 export const EmptyKeywords: Story = {
   args: {
     positiveRatio: 50,

--- a/src/components/Detail/KeywordBubbleMap/KeywordBubbleMap.stories.tsx
+++ b/src/components/Detail/KeywordBubbleMap/KeywordBubbleMap.stories.tsx
@@ -162,3 +162,14 @@ export const WithEmptyArticles: Story = {
     ],
   },
 };
+
+export const EmptyKeywords: Story = {
+  args: {
+    positiveRatio: 50,
+    negativeRatio: 50,
+    positiveKeywords: mockPositiveKeywords,
+    negativeKeywords: mockNegativeKeywords,
+    isEmpty: true,
+    date: '2025-05-30',
+  },
+};

--- a/src/components/Detail/KeywordBubbleMap/constants.ts
+++ b/src/components/Detail/KeywordBubbleMap/constants.ts
@@ -6,11 +6,11 @@ export const PILL_HEIGHT = 30;
 export const PILL_RADIUS = PILL_HEIGHT / 2;
 export const MAX_ORBIT = 74;
 
-export const NEWS_PILL_WIDTH = 150;
+export const NEWS_PILL_WIDTH = 200;
 export const NEWS_PILL_HEIGHT = 34;
 export const NEWS_PILL_RADIUS = 10;
 export const NEWS_ICON_SIZE = 14;
-export const NEWS_MAX_CHARS = 10;
+export const NEWS_MAX_CHARS = 21;
 export const NEWS_ORBIT = 115;
 
 export const POS_FILL = '#FBEBF0';

--- a/src/components/Detail/KeywordBubbleMap/index.tsx
+++ b/src/components/Detail/KeywordBubbleMap/index.tsx
@@ -29,6 +29,7 @@ import {
   calcNewsOrbit,
   calcNewsPositions,
   calcKeywordOrbit,
+  newsPillWidth,
   pillWidth,
   truncateTitle,
 } from './positions';
@@ -81,7 +82,13 @@ export default function KeywordBubbleMap({
   );
 
   const displayedArticles = selected?.articles.slice(0, 5) ?? [];
-  const newsOrbit = selected ? calcNewsOrbit(selected.keyword) : NEWS_ORBIT;
+  const newsTitles = displayedArticles.map((a) => truncateTitle(a.title));
+  const newsPillWidths = newsTitles.map(newsPillWidth);
+  const maxNewsPillWidth =
+    newsPillWidths.length > 0 ? Math.max(...newsPillWidths) : NEWS_PILL_WIDTH;
+  const newsOrbit = selected
+    ? calcNewsOrbit(selected.keyword, maxNewsPillWidth)
+    : NEWS_ORBIT;
   const newsPos = calcNewsPositions(displayedArticles.length, newsOrbit);
 
   const isPos = (selected?.sentiment ?? 0) === 1;
@@ -335,8 +342,9 @@ export default function KeywordBubbleMap({
             {selected !== null &&
               displayedArticles.map((article, i) => {
                 const { x, y } = newsPos[i];
-                const title = truncateTitle(article.title);
-                const pl = x - NEWS_PILL_WIDTH / 2;
+                const title = newsTitles[i];
+                const newsPillWidth = newsPillWidths[i];
+                const pl = x - newsPillWidth / 2;
                 const pt = y - NEWS_PILL_HEIGHT / 2;
 
                 return (
@@ -373,7 +381,7 @@ export default function KeywordBubbleMap({
                     <rect
                       x={pl}
                       y={pt}
-                      width={NEWS_PILL_WIDTH}
+                      width={newsPillWidth}
                       height={NEWS_PILL_HEIGHT}
                       rx={NEWS_PILL_RADIUS}
                       fill="white"

--- a/src/components/Detail/KeywordBubbleMap/index.tsx
+++ b/src/components/Detail/KeywordBubbleMap/index.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
-import { IoDocumentTextOutline } from 'react-icons/io5';
+import { IoCalendarOutline, IoDocumentTextOutline } from 'react-icons/io5';
 import styled from 'styled-components';
 import type { KeywordsWithArticleResponse } from '@/types';
 import {
@@ -46,6 +46,7 @@ type Props = {
   onNewsClick: (articleId: string) => void;
   date: string;
   onDateChange?: (date: string) => void;
+  isEmpty?: boolean;
 };
 
 export default function KeywordBubbleMap({
@@ -56,6 +57,7 @@ export default function KeywordBubbleMap({
   onNewsClick,
   date,
   onDateChange,
+  isEmpty = false,
 }: Props) {
   const isMobile = useIsMobile();
   const uid = useRef(Math.random().toString(36).slice(2, 8)).current;
@@ -110,320 +112,330 @@ export default function KeywordBubbleMap({
           />
         )}
       </BubbleMapHeader>
-      <Container onClick={close}>
-        <Background $ratio={positiveRatio} />
-        <DateText>{date}</DateText>
+      <Container onClick={isEmpty ? undefined : close}>
+        <BlurContent $blurred={isEmpty}>
+          <Background $ratio={positiveRatio} />
+          <DateText>{date}</DateText>
 
-        <Svg
-          viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`}
-          preserveAspectRatio="xMidYMid meet"
-          style={{ fontFamily: 'Pretendard, sans-serif' }}
-        >
-          <defs>
-            <filter
-              id={posShadowId}
-              x="-30%"
-              y="-30%"
-              width="160%"
-              height="160%"
-            >
-              <feDropShadow
-                dx="2"
-                dy="2"
-                stdDeviation="2.5"
-                floodColor="rgba(237,202,206,0.35)"
-              />
-            </filter>
-            <filter
-              id={negShadowId}
-              x="-30%"
-              y="-30%"
-              width="160%"
-              height="160%"
-            >
-              <feDropShadow
-                dx="2"
-                dy="2"
-                stdDeviation="2.5"
-                floodColor="rgba(169,204,253,0.35)"
-              />
-            </filter>
-
-            <filter
-              id={newsShadowId}
-              x="-20%"
-              y="-40%"
-              width="140%"
-              height="180%"
-            >
-              <feDropShadow
-                dx="0"
-                dy="3"
-                stdDeviation="5"
-                floodColor="rgba(0,0,0,0.10)"
-              />
-            </filter>
-          </defs>
-
-          <AnimatePresence>
-            {selected !== null && (
-              <motion.rect
-                key="dim"
-                x={0}
-                y={0}
-                width={SVG_WIDTH}
-                height={SVG_HEIGHT}
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.3 }}
-                fill={
-                  isPos ? 'rgba(255,245,247,0.94)' : 'rgba(245,250,255,0.94)'
-                }
-                style={{ cursor: 'default' }}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  close();
-                }}
-              />
-            )}
-          </AnimatePresence>
-
-          {positiveKeywords.map((kw, i) => {
-            const { x, y } = posPos[i];
-            const pw = pillWidth(kw.keyword);
-            const isSelected = selected?.keyword === kw.keyword;
-            const isDimmed = selected !== null && !isSelected;
-            const hasArticles = kw.articles.length > 0;
-            const fill = hasArticles ? POS_FILL : EMPTY_FILL;
-            const stroke = hasArticles ? POS_STROKE : EMPTY_STROKE;
-            const textFill = hasArticles ? POS_TEXT : EMPTY_TEXT;
-
-            return (
-              <motion.g
-                key={kw.keyword}
-                role="button"
-                tabIndex={isDimmed ? -1 : 0}
-                animate={{
-                  x: isSelected ? SVG_WIDTH / 2 - x : 0,
-                  y: isSelected ? SVG_CENTER_Y - y : 0,
-                  opacity: isDimmed ? 0 : 1,
-                }}
-                transition={{ duration: 0.35, ease: 'easeOut' }}
-                whileHover={
-                  selected === null && hasArticles ? { scale: 1.08 } : {}
-                }
-                whileFocus={
-                  selected === null && hasArticles ? { scale: 1.08 } : {}
-                }
-                style={{
-                  transformOrigin: `${x}px ${y}px`,
-                  cursor:
-                    selected === null && hasArticles ? 'pointer' : 'default',
-                  outline: 'none',
-                }}
-                onClick={(e) => {
-                  if (selected === null && hasArticles) {
-                    e.stopPropagation();
-                    setSelected(kw);
-                  }
-                }}
-                onKeyDown={(e) => {
-                  if (
-                    selected === null &&
-                    hasArticles &&
-                    (e.key === 'Enter' || e.key === ' ')
-                  ) {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    setSelected(kw);
-                  }
-                }}
+          <Svg
+            viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`}
+            preserveAspectRatio="xMidYMid meet"
+            style={{ fontFamily: 'Pretendard, sans-serif' }}
+          >
+            <defs>
+              <filter
+                id={posShadowId}
+                x="-30%"
+                y="-30%"
+                width="160%"
+                height="160%"
               >
-                <rect
-                  x={x - pw / 2}
-                  y={y - PILL_HEIGHT / 2}
-                  width={pw}
-                  height={PILL_HEIGHT}
-                  rx={PILL_RADIUS}
-                  fill={fill}
-                  stroke={stroke}
-                  strokeWidth={1}
-                  filter={`url(#${posShadowId})`}
+                <feDropShadow
+                  dx="2"
+                  dy="2"
+                  stdDeviation="2.5"
+                  floodColor="rgba(237,202,206,0.35)"
                 />
-                <text
-                  x={x}
-                  y={y}
-                  textAnchor="middle"
-                  dominantBaseline="middle"
-                  fontSize={13}
-                  fontWeight="600"
-                  fill={textFill}
-                  style={{ pointerEvents: 'none' }}
-                >
-                  {kw.keyword}
-                </text>
-              </motion.g>
-            );
-          })}
-
-          {negativeKeywords.map((kw, i) => {
-            const { x, y } = negPos[i];
-            const pw = pillWidth(kw.keyword);
-            const isSelected = selected?.keyword === kw.keyword;
-            const isDimmed = selected !== null && !isSelected;
-            const hasArticles = kw.articles.length > 0;
-            const fill = hasArticles ? NEG_FILL : EMPTY_FILL;
-            const stroke = hasArticles ? NEG_STROKE : EMPTY_STROKE;
-            const textFill = hasArticles ? NEG_TEXT : EMPTY_TEXT;
-
-            return (
-              <motion.g
-                key={kw.keyword}
-                role="button"
-                tabIndex={isDimmed ? -1 : 0}
-                animate={{
-                  x: isSelected ? SVG_WIDTH / 2 - x : 0,
-                  y: isSelected ? SVG_CENTER_Y - y : 0,
-                  opacity: isDimmed ? 0 : 1,
-                }}
-                transition={{ duration: 0.35, ease: 'easeOut' }}
-                whileHover={
-                  selected === null && hasArticles ? { scale: 1.08 } : {}
-                }
-                whileFocus={
-                  selected === null && hasArticles ? { scale: 1.08 } : {}
-                }
-                style={{
-                  transformOrigin: `${x}px ${y}px`,
-                  cursor:
-                    selected === null && hasArticles ? 'pointer' : 'default',
-                  outline: 'none',
-                }}
-                onClick={(e) => {
-                  if (selected === null && hasArticles) {
-                    e.stopPropagation();
-                    setSelected(kw);
-                  }
-                }}
-                onKeyDown={(e) => {
-                  if (
-                    selected === null &&
-                    hasArticles &&
-                    (e.key === 'Enter' || e.key === ' ')
-                  ) {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    setSelected(kw);
-                  }
-                }}
+              </filter>
+              <filter
+                id={negShadowId}
+                x="-30%"
+                y="-30%"
+                width="160%"
+                height="160%"
               >
-                <rect
-                  x={x - pw / 2}
-                  y={y - PILL_HEIGHT / 2}
-                  width={pw}
-                  height={PILL_HEIGHT}
-                  rx={PILL_RADIUS}
-                  fill={fill}
-                  stroke={stroke}
-                  strokeWidth={1}
-                  filter={`url(#${negShadowId})`}
+                <feDropShadow
+                  dx="2"
+                  dy="2"
+                  stdDeviation="2.5"
+                  floodColor="rgba(169,204,253,0.35)"
                 />
-                <text
-                  x={x}
-                  y={y}
-                  textAnchor="middle"
-                  dominantBaseline="middle"
-                  fontSize={13}
-                  fontWeight="600"
-                  fill={textFill}
-                  style={{ pointerEvents: 'none' }}
-                >
-                  {kw.keyword}
-                </text>
-              </motion.g>
-            );
-          })}
+              </filter>
 
-          <AnimatePresence>
-            {selected !== null &&
-              displayedArticles.map((article, i) => {
-                const { x, y } = newsPos[i];
-                const title = truncateTitle(article.title);
-                const pl = x - NEWS_PILL_WIDTH / 2;
-                const pt = y - NEWS_PILL_HEIGHT / 2;
+              <filter
+                id={newsShadowId}
+                x="-20%"
+                y="-40%"
+                width="140%"
+                height="180%"
+              >
+                <feDropShadow
+                  dx="0"
+                  dy="3"
+                  stdDeviation="5"
+                  floodColor="rgba(0,0,0,0.10)"
+                />
+              </filter>
+            </defs>
 
-                return (
-                  <motion.g
-                    key={`news-${article.articleId}`}
-                    role="button"
-                    tabIndex={0}
-                    initial={{ opacity: 0, scale: 0.75 }}
-                    animate={{ opacity: 1, scale: 1 }}
-                    exit={{ opacity: 0, scale: 0.75 }}
-                    transition={{
-                      duration: 0.22,
-                      delay: 0.12 + i * 0.05,
-                      ease: 'easeOut',
-                    }}
-                    whileHover={{ scale: 1.04 }}
-                    whileFocus={{ scale: 1.04 }}
-                    style={{
-                      cursor: 'pointer',
-                      transformOrigin: `${x}px ${y}px`,
-                    }}
-                    onClick={(e) => {
+            <AnimatePresence>
+              {selected !== null && (
+                <motion.rect
+                  key="dim"
+                  x={0}
+                  y={0}
+                  width={SVG_WIDTH}
+                  height={SVG_HEIGHT}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.3 }}
+                  fill={
+                    isPos ? 'rgba(255,245,247,0.94)' : 'rgba(245,250,255,0.94)'
+                  }
+                  style={{ cursor: 'default' }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    close();
+                  }}
+                />
+              )}
+            </AnimatePresence>
+
+            {positiveKeywords.map((kw, i) => {
+              const { x, y } = posPos[i];
+              const pw = pillWidth(kw.keyword);
+              const isSelected = selected?.keyword === kw.keyword;
+              const isDimmed = selected !== null && !isSelected;
+              const hasArticles = kw.articles.length > 0;
+              const fill = hasArticles ? POS_FILL : EMPTY_FILL;
+              const stroke = hasArticles ? POS_STROKE : EMPTY_STROKE;
+              const textFill = hasArticles ? POS_TEXT : EMPTY_TEXT;
+
+              return (
+                <motion.g
+                  key={kw.keyword}
+                  role="button"
+                  tabIndex={isDimmed ? -1 : 0}
+                  animate={{
+                    x: isSelected ? SVG_WIDTH / 2 - x : 0,
+                    y: isSelected ? SVG_CENTER_Y - y : 0,
+                    opacity: isDimmed ? 0 : 1,
+                  }}
+                  transition={{ duration: 0.35, ease: 'easeOut' }}
+                  whileHover={
+                    selected === null && hasArticles ? { scale: 1.08 } : {}
+                  }
+                  whileFocus={
+                    selected === null && hasArticles ? { scale: 1.08 } : {}
+                  }
+                  style={{
+                    transformOrigin: `${x}px ${y}px`,
+                    cursor:
+                      selected === null && hasArticles ? 'pointer' : 'default',
+                    outline: 'none',
+                  }}
+                  onClick={(e) => {
+                    if (selected === null && hasArticles) {
                       e.stopPropagation();
-                      onNewsClick(article.articleId);
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
+                      setSelected(kw);
+                    }
+                  }}
+                  onKeyDown={(e) => {
+                    if (
+                      selected === null &&
+                      hasArticles &&
+                      (e.key === 'Enter' || e.key === ' ')
+                    ) {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      setSelected(kw);
+                    }
+                  }}
+                >
+                  <rect
+                    x={x - pw / 2}
+                    y={y - PILL_HEIGHT / 2}
+                    width={pw}
+                    height={PILL_HEIGHT}
+                    rx={PILL_RADIUS}
+                    fill={fill}
+                    stroke={stroke}
+                    strokeWidth={1}
+                    filter={`url(#${posShadowId})`}
+                  />
+                  <text
+                    x={x}
+                    y={y}
+                    textAnchor="middle"
+                    dominantBaseline="middle"
+                    fontSize={13}
+                    fontWeight="600"
+                    fill={textFill}
+                    style={{ pointerEvents: 'none' }}
+                  >
+                    {kw.keyword}
+                  </text>
+                </motion.g>
+              );
+            })}
+
+            {negativeKeywords.map((kw, i) => {
+              const { x, y } = negPos[i];
+              const pw = pillWidth(kw.keyword);
+              const isSelected = selected?.keyword === kw.keyword;
+              const isDimmed = selected !== null && !isSelected;
+              const hasArticles = kw.articles.length > 0;
+              const fill = hasArticles ? NEG_FILL : EMPTY_FILL;
+              const stroke = hasArticles ? NEG_STROKE : EMPTY_STROKE;
+              const textFill = hasArticles ? NEG_TEXT : EMPTY_TEXT;
+
+              return (
+                <motion.g
+                  key={kw.keyword}
+                  role="button"
+                  tabIndex={isDimmed ? -1 : 0}
+                  animate={{
+                    x: isSelected ? SVG_WIDTH / 2 - x : 0,
+                    y: isSelected ? SVG_CENTER_Y - y : 0,
+                    opacity: isDimmed ? 0 : 1,
+                  }}
+                  transition={{ duration: 0.35, ease: 'easeOut' }}
+                  whileHover={
+                    selected === null && hasArticles ? { scale: 1.08 } : {}
+                  }
+                  whileFocus={
+                    selected === null && hasArticles ? { scale: 1.08 } : {}
+                  }
+                  style={{
+                    transformOrigin: `${x}px ${y}px`,
+                    cursor:
+                      selected === null && hasArticles ? 'pointer' : 'default',
+                    outline: 'none',
+                  }}
+                  onClick={(e) => {
+                    if (selected === null && hasArticles) {
+                      e.stopPropagation();
+                      setSelected(kw);
+                    }
+                  }}
+                  onKeyDown={(e) => {
+                    if (
+                      selected === null &&
+                      hasArticles &&
+                      (e.key === 'Enter' || e.key === ' ')
+                    ) {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      setSelected(kw);
+                    }
+                  }}
+                >
+                  <rect
+                    x={x - pw / 2}
+                    y={y - PILL_HEIGHT / 2}
+                    width={pw}
+                    height={PILL_HEIGHT}
+                    rx={PILL_RADIUS}
+                    fill={fill}
+                    stroke={stroke}
+                    strokeWidth={1}
+                    filter={`url(#${negShadowId})`}
+                  />
+                  <text
+                    x={x}
+                    y={y}
+                    textAnchor="middle"
+                    dominantBaseline="middle"
+                    fontSize={13}
+                    fontWeight="600"
+                    fill={textFill}
+                    style={{ pointerEvents: 'none' }}
+                  >
+                    {kw.keyword}
+                  </text>
+                </motion.g>
+              );
+            })}
+
+            <AnimatePresence>
+              {selected !== null &&
+                displayedArticles.map((article, i) => {
+                  const { x, y } = newsPos[i];
+                  const title = truncateTitle(article.title);
+                  const pl = x - NEWS_PILL_WIDTH / 2;
+                  const pt = y - NEWS_PILL_HEIGHT / 2;
+
+                  return (
+                    <motion.g
+                      key={`news-${article.articleId}`}
+                      role="button"
+                      tabIndex={0}
+                      initial={{ opacity: 0, scale: 0.75 }}
+                      animate={{ opacity: 1, scale: 1 }}
+                      exit={{ opacity: 0, scale: 0.75 }}
+                      transition={{
+                        duration: 0.22,
+                        delay: 0.12 + i * 0.05,
+                        ease: 'easeOut',
+                      }}
+                      whileHover={{ scale: 1.04 }}
+                      whileFocus={{ scale: 1.04 }}
+                      style={{
+                        cursor: 'pointer',
+                        transformOrigin: `${x}px ${y}px`,
+                      }}
+                      onClick={(e) => {
                         e.stopPropagation();
                         onNewsClick(article.articleId);
-                      }
-                    }}
-                  >
-                    <rect
-                      x={pl}
-                      y={pt}
-                      width={NEWS_PILL_WIDTH}
-                      height={NEWS_PILL_HEIGHT}
-                      rx={NEWS_PILL_RADIUS}
-                      fill="white"
-                      stroke={drillStroke}
-                      strokeWidth={1}
-                      filter={`url(#${newsShadowId})`}
-                    />
-                    <svg
-                      x={pl + 8}
-                      y={y - NEWS_ICON_SIZE / 2}
-                      width={NEWS_ICON_SIZE}
-                      height={NEWS_ICON_SIZE}
-                      style={{ pointerEvents: 'none', overflow: 'visible' }}
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          onNewsClick(article.articleId);
+                        }
+                      }}
                     >
-                      <IoDocumentTextOutline
+                      <rect
+                        x={pl}
+                        y={pt}
+                        width={NEWS_PILL_WIDTH}
+                        height={NEWS_PILL_HEIGHT}
+                        rx={NEWS_PILL_RADIUS}
+                        fill="white"
+                        stroke={drillStroke}
+                        strokeWidth={1}
+                        filter={`url(#${newsShadowId})`}
+                      />
+                      <svg
+                        x={pl + 8}
+                        y={y - NEWS_ICON_SIZE / 2}
                         width={NEWS_ICON_SIZE}
                         height={NEWS_ICON_SIZE}
-                        color={drillAccent}
-                      />
-                    </svg>
-                    <text
-                      x={pl + 8 + NEWS_ICON_SIZE + 5}
-                      y={y + 0.5}
-                      dominantBaseline="middle"
-                      fontSize={11}
-                      fontWeight="500"
-                      fill="#374151"
-                      style={{ pointerEvents: 'none' }}
-                    >
-                      {title}
-                    </text>
-                  </motion.g>
-                );
-              })}
-          </AnimatePresence>
-        </Svg>
+                        style={{ pointerEvents: 'none', overflow: 'visible' }}
+                      >
+                        <IoDocumentTextOutline
+                          width={NEWS_ICON_SIZE}
+                          height={NEWS_ICON_SIZE}
+                          color={drillAccent}
+                        />
+                      </svg>
+                      <text
+                        x={pl + 8 + NEWS_ICON_SIZE + 5}
+                        y={y + 0.5}
+                        dominantBaseline="middle"
+                        fontSize={11}
+                        fontWeight="500"
+                        fill="#374151"
+                        style={{ pointerEvents: 'none' }}
+                      >
+                        {title}
+                      </text>
+                    </motion.g>
+                  );
+                })}
+            </AnimatePresence>
+          </Svg>
+        </BlurContent>
+        {isEmpty && (
+          <EmptyOverlay>
+            <IoCalendarOutline size={36} color="#9ca3af" />
+            <Text size="xs" weight="bold" variant="#62676d">
+              해당 날짜에 생성된 키워드가 없어요!
+            </Text>
+          </EmptyOverlay>
+        )}
       </Container>
     </>
   );
@@ -472,4 +484,22 @@ const Svg = styled.svg`
   inset: 0;
   width: 100%;
   height: 100%;
+`;
+
+const BlurContent = styled.div<{ $blurred: boolean }>`
+  position: absolute;
+  inset: 0;
+  filter: ${({ $blurred }) => ($blurred ? 'blur(8px)' : 'none')};
+  pointer-events: ${({ $blurred }) => ($blurred ? 'none' : 'auto')};
+`;
+
+const EmptyOverlay = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  inset: 0;
+  gap: 16px;
+  z-index: 2;
 `;

--- a/src/components/Detail/KeywordBubbleMap/index.tsx
+++ b/src/components/Detail/KeywordBubbleMap/index.tsx
@@ -196,7 +196,7 @@ export default function KeywordBubbleMap({
               <motion.g
                 key={kw.keyword}
                 role="button"
-                tabIndex={isDimmed ? -1 : 0}
+                tabIndex={isDimmed || isEmpty ? -1 : 0}
                 animate={{
                   x: isSelected ? SVG_WIDTH / 2 - x : 0,
                   y: isSelected ? SVG_CENTER_Y - y : 0,
@@ -223,6 +223,7 @@ export default function KeywordBubbleMap({
                 }}
                 onKeyDown={(e) => {
                   if (
+                    !isEmpty &&
                     selected === null &&
                     hasArticles &&
                     (e.key === 'Enter' || e.key === ' ')
@@ -274,7 +275,7 @@ export default function KeywordBubbleMap({
               <motion.g
                 key={kw.keyword}
                 role="button"
-                tabIndex={isDimmed ? -1 : 0}
+                tabIndex={isDimmed || isEmpty ? -1 : 0}
                 animate={{
                   x: isSelected ? SVG_WIDTH / 2 - x : 0,
                   y: isSelected ? SVG_CENTER_Y - y : 0,
@@ -301,6 +302,7 @@ export default function KeywordBubbleMap({
                 }}
                 onKeyDown={(e) => {
                   if (
+                    !isEmpty &&
                     selected === null &&
                     hasArticles &&
                     (e.key === 'Enter' || e.key === ' ')

--- a/src/components/Detail/KeywordBubbleMap/index.tsx
+++ b/src/components/Detail/KeywordBubbleMap/index.tsx
@@ -32,11 +32,7 @@ import {
   pillWidth,
   truncateTitle,
 } from './positions';
-import { Paragraph } from '@/components/common/typography/Paragraph';
 import { Text } from '@/components/common/typography/Text';
-import useIsMobile from '@/hooks/useIsMobile';
-import DatePickerButton from '@/components/common/DatePickerButton';
-import { formatMonthDay } from '@/utils/formatDate';
 
 type Props = {
   positiveRatio: number;
@@ -45,7 +41,6 @@ type Props = {
   negativeKeywords: KeywordsWithArticleResponse[];
   onNewsClick: (articleId: string) => void;
   date: string;
-  onDateChange?: (date: string) => void;
   isEmpty?: boolean;
 };
 
@@ -56,10 +51,8 @@ export default function KeywordBubbleMap({
   negativeKeywords,
   onNewsClick,
   date,
-  onDateChange,
   isEmpty = false,
 }: Props) {
-  const isMobile = useIsMobile();
   const uid = useRef(Math.random().toString(36).slice(2, 8)).current;
   const [selected, setSelected] = useState<KeywordsWithArticleResponse | null>(
     null
@@ -96,358 +89,333 @@ export default function KeywordBubbleMap({
   const newsShadowId = `${uid}-ns`;
 
   return (
-    <>
-      <BubbleMapHeader>
-        <Paragraph size={isMobile ? 'xs' : 's'} weight="bold">
-          <Text size={isMobile ? 'xs' : 's'} weight="bold" variant="#2d70d3">
-            {formatMonthDay(date)}
-          </Text>
-          의 뉴스 요약
-        </Paragraph>
-        {onDateChange && (
-          <DatePickerButton
-            selectedDate={date}
-            onDateChange={onDateChange}
-            popupZIndex={9}
-          />
-        )}
-      </BubbleMapHeader>
-      <Container onClick={isEmpty ? undefined : close}>
-        <BlurContent $blurred={isEmpty}>
-          <Background $ratio={positiveRatio} />
-          <DateText>{date}</DateText>
+    <Container onClick={isEmpty ? undefined : close}>
+      <BlurContent $blurred={isEmpty}>
+        <Background $ratio={positiveRatio} />
+        <DateText>{date}</DateText>
 
-          <Svg
-            viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`}
-            preserveAspectRatio="xMidYMid meet"
-            style={{ fontFamily: 'Pretendard, sans-serif' }}
-          >
-            <defs>
-              <filter
-                id={posShadowId}
-                x="-30%"
-                y="-30%"
-                width="160%"
-                height="160%"
-              >
-                <feDropShadow
-                  dx="2"
-                  dy="2"
-                  stdDeviation="2.5"
-                  floodColor="rgba(237,202,206,0.35)"
-                />
-              </filter>
-              <filter
-                id={negShadowId}
-                x="-30%"
-                y="-30%"
-                width="160%"
-                height="160%"
-              >
-                <feDropShadow
-                  dx="2"
-                  dy="2"
-                  stdDeviation="2.5"
-                  floodColor="rgba(169,204,253,0.35)"
-                />
-              </filter>
+        <Svg
+          viewBox={`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`}
+          preserveAspectRatio="xMidYMid meet"
+          style={{ fontFamily: 'Pretendard, sans-serif' }}
+        >
+          <defs>
+            <filter
+              id={posShadowId}
+              x="-30%"
+              y="-30%"
+              width="160%"
+              height="160%"
+            >
+              <feDropShadow
+                dx="2"
+                dy="2"
+                stdDeviation="2.5"
+                floodColor="rgba(237,202,206,0.35)"
+              />
+            </filter>
+            <filter
+              id={negShadowId}
+              x="-30%"
+              y="-30%"
+              width="160%"
+              height="160%"
+            >
+              <feDropShadow
+                dx="2"
+                dy="2"
+                stdDeviation="2.5"
+                floodColor="rgba(169,204,253,0.35)"
+              />
+            </filter>
 
-              <filter
-                id={newsShadowId}
-                x="-20%"
-                y="-40%"
-                width="140%"
-                height="180%"
-              >
-                <feDropShadow
-                  dx="0"
-                  dy="3"
-                  stdDeviation="5"
-                  floodColor="rgba(0,0,0,0.10)"
-                />
-              </filter>
-            </defs>
+            <filter
+              id={newsShadowId}
+              x="-20%"
+              y="-40%"
+              width="140%"
+              height="180%"
+            >
+              <feDropShadow
+                dx="0"
+                dy="3"
+                stdDeviation="5"
+                floodColor="rgba(0,0,0,0.10)"
+              />
+            </filter>
+          </defs>
 
-            <AnimatePresence>
-              {selected !== null && (
-                <motion.rect
-                  key="dim"
-                  x={0}
-                  y={0}
-                  width={SVG_WIDTH}
-                  height={SVG_HEIGHT}
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  transition={{ duration: 0.3 }}
-                  fill={
-                    isPos ? 'rgba(255,245,247,0.94)' : 'rgba(245,250,255,0.94)'
-                  }
-                  style={{ cursor: 'default' }}
-                  onClick={(e) => {
+          <AnimatePresence>
+            {selected !== null && (
+              <motion.rect
+                key="dim"
+                x={0}
+                y={0}
+                width={SVG_WIDTH}
+                height={SVG_HEIGHT}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.3 }}
+                fill={
+                  isPos ? 'rgba(255,245,247,0.94)' : 'rgba(245,250,255,0.94)'
+                }
+                style={{ cursor: 'default' }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  close();
+                }}
+              />
+            )}
+          </AnimatePresence>
+
+          {positiveKeywords.map((kw, i) => {
+            const { x, y } = posPos[i];
+            const pw = pillWidth(kw.keyword);
+            const isSelected = selected?.keyword === kw.keyword;
+            const isDimmed = selected !== null && !isSelected;
+            const hasArticles = kw.articles.length > 0;
+            const fill = hasArticles ? POS_FILL : EMPTY_FILL;
+            const stroke = hasArticles ? POS_STROKE : EMPTY_STROKE;
+            const textFill = hasArticles ? POS_TEXT : EMPTY_TEXT;
+
+            return (
+              <motion.g
+                key={kw.keyword}
+                role="button"
+                tabIndex={isDimmed ? -1 : 0}
+                animate={{
+                  x: isSelected ? SVG_WIDTH / 2 - x : 0,
+                  y: isSelected ? SVG_CENTER_Y - y : 0,
+                  opacity: isDimmed ? 0 : 1,
+                }}
+                transition={{ duration: 0.35, ease: 'easeOut' }}
+                whileHover={
+                  selected === null && hasArticles ? { scale: 1.08 } : {}
+                }
+                whileFocus={
+                  selected === null && hasArticles ? { scale: 1.08 } : {}
+                }
+                style={{
+                  transformOrigin: `${x}px ${y}px`,
+                  cursor:
+                    selected === null && hasArticles ? 'pointer' : 'default',
+                  outline: 'none',
+                }}
+                onClick={(e) => {
+                  if (selected === null && hasArticles) {
                     e.stopPropagation();
-                    close();
-                  }}
+                    setSelected(kw);
+                  }
+                }}
+                onKeyDown={(e) => {
+                  if (
+                    selected === null &&
+                    hasArticles &&
+                    (e.key === 'Enter' || e.key === ' ')
+                  ) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setSelected(kw);
+                  }
+                }}
+              >
+                <rect
+                  x={x - pw / 2}
+                  y={y - PILL_HEIGHT / 2}
+                  width={pw}
+                  height={PILL_HEIGHT}
+                  rx={PILL_RADIUS}
+                  fill={fill}
+                  stroke={stroke}
+                  strokeWidth={1}
+                  filter={`url(#${posShadowId})`}
                 />
-              )}
-            </AnimatePresence>
-
-            {positiveKeywords.map((kw, i) => {
-              const { x, y } = posPos[i];
-              const pw = pillWidth(kw.keyword);
-              const isSelected = selected?.keyword === kw.keyword;
-              const isDimmed = selected !== null && !isSelected;
-              const hasArticles = kw.articles.length > 0;
-              const fill = hasArticles ? POS_FILL : EMPTY_FILL;
-              const stroke = hasArticles ? POS_STROKE : EMPTY_STROKE;
-              const textFill = hasArticles ? POS_TEXT : EMPTY_TEXT;
-
-              return (
-                <motion.g
-                  key={kw.keyword}
-                  role="button"
-                  tabIndex={isDimmed ? -1 : 0}
-                  animate={{
-                    x: isSelected ? SVG_WIDTH / 2 - x : 0,
-                    y: isSelected ? SVG_CENTER_Y - y : 0,
-                    opacity: isDimmed ? 0 : 1,
-                  }}
-                  transition={{ duration: 0.35, ease: 'easeOut' }}
-                  whileHover={
-                    selected === null && hasArticles ? { scale: 1.08 } : {}
-                  }
-                  whileFocus={
-                    selected === null && hasArticles ? { scale: 1.08 } : {}
-                  }
-                  style={{
-                    transformOrigin: `${x}px ${y}px`,
-                    cursor:
-                      selected === null && hasArticles ? 'pointer' : 'default',
-                    outline: 'none',
-                  }}
-                  onClick={(e) => {
-                    if (selected === null && hasArticles) {
-                      e.stopPropagation();
-                      setSelected(kw);
-                    }
-                  }}
-                  onKeyDown={(e) => {
-                    if (
-                      selected === null &&
-                      hasArticles &&
-                      (e.key === 'Enter' || e.key === ' ')
-                    ) {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      setSelected(kw);
-                    }
-                  }}
+                <text
+                  x={x}
+                  y={y}
+                  textAnchor="middle"
+                  dominantBaseline="middle"
+                  fontSize={13}
+                  fontWeight="600"
+                  fill={textFill}
+                  style={{ pointerEvents: 'none' }}
                 >
-                  <rect
-                    x={x - pw / 2}
-                    y={y - PILL_HEIGHT / 2}
-                    width={pw}
-                    height={PILL_HEIGHT}
-                    rx={PILL_RADIUS}
-                    fill={fill}
-                    stroke={stroke}
-                    strokeWidth={1}
-                    filter={`url(#${posShadowId})`}
-                  />
-                  <text
-                    x={x}
-                    y={y}
-                    textAnchor="middle"
-                    dominantBaseline="middle"
-                    fontSize={13}
-                    fontWeight="600"
-                    fill={textFill}
-                    style={{ pointerEvents: 'none' }}
-                  >
-                    {kw.keyword}
-                  </text>
-                </motion.g>
-              );
-            })}
+                  {kw.keyword}
+                </text>
+              </motion.g>
+            );
+          })}
 
-            {negativeKeywords.map((kw, i) => {
-              const { x, y } = negPos[i];
-              const pw = pillWidth(kw.keyword);
-              const isSelected = selected?.keyword === kw.keyword;
-              const isDimmed = selected !== null && !isSelected;
-              const hasArticles = kw.articles.length > 0;
-              const fill = hasArticles ? NEG_FILL : EMPTY_FILL;
-              const stroke = hasArticles ? NEG_STROKE : EMPTY_STROKE;
-              const textFill = hasArticles ? NEG_TEXT : EMPTY_TEXT;
+          {negativeKeywords.map((kw, i) => {
+            const { x, y } = negPos[i];
+            const pw = pillWidth(kw.keyword);
+            const isSelected = selected?.keyword === kw.keyword;
+            const isDimmed = selected !== null && !isSelected;
+            const hasArticles = kw.articles.length > 0;
+            const fill = hasArticles ? NEG_FILL : EMPTY_FILL;
+            const stroke = hasArticles ? NEG_STROKE : EMPTY_STROKE;
+            const textFill = hasArticles ? NEG_TEXT : EMPTY_TEXT;
 
-              return (
-                <motion.g
-                  key={kw.keyword}
-                  role="button"
-                  tabIndex={isDimmed ? -1 : 0}
-                  animate={{
-                    x: isSelected ? SVG_WIDTH / 2 - x : 0,
-                    y: isSelected ? SVG_CENTER_Y - y : 0,
-                    opacity: isDimmed ? 0 : 1,
-                  }}
-                  transition={{ duration: 0.35, ease: 'easeOut' }}
-                  whileHover={
-                    selected === null && hasArticles ? { scale: 1.08 } : {}
+            return (
+              <motion.g
+                key={kw.keyword}
+                role="button"
+                tabIndex={isDimmed ? -1 : 0}
+                animate={{
+                  x: isSelected ? SVG_WIDTH / 2 - x : 0,
+                  y: isSelected ? SVG_CENTER_Y - y : 0,
+                  opacity: isDimmed ? 0 : 1,
+                }}
+                transition={{ duration: 0.35, ease: 'easeOut' }}
+                whileHover={
+                  selected === null && hasArticles ? { scale: 1.08 } : {}
+                }
+                whileFocus={
+                  selected === null && hasArticles ? { scale: 1.08 } : {}
+                }
+                style={{
+                  transformOrigin: `${x}px ${y}px`,
+                  cursor:
+                    selected === null && hasArticles ? 'pointer' : 'default',
+                  outline: 'none',
+                }}
+                onClick={(e) => {
+                  if (selected === null && hasArticles) {
+                    e.stopPropagation();
+                    setSelected(kw);
                   }
-                  whileFocus={
-                    selected === null && hasArticles ? { scale: 1.08 } : {}
+                }}
+                onKeyDown={(e) => {
+                  if (
+                    selected === null &&
+                    hasArticles &&
+                    (e.key === 'Enter' || e.key === ' ')
+                  ) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setSelected(kw);
                   }
-                  style={{
-                    transformOrigin: `${x}px ${y}px`,
-                    cursor:
-                      selected === null && hasArticles ? 'pointer' : 'default',
-                    outline: 'none',
-                  }}
-                  onClick={(e) => {
-                    if (selected === null && hasArticles) {
-                      e.stopPropagation();
-                      setSelected(kw);
-                    }
-                  }}
-                  onKeyDown={(e) => {
-                    if (
-                      selected === null &&
-                      hasArticles &&
-                      (e.key === 'Enter' || e.key === ' ')
-                    ) {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      setSelected(kw);
-                    }
-                  }}
+                }}
+              >
+                <rect
+                  x={x - pw / 2}
+                  y={y - PILL_HEIGHT / 2}
+                  width={pw}
+                  height={PILL_HEIGHT}
+                  rx={PILL_RADIUS}
+                  fill={fill}
+                  stroke={stroke}
+                  strokeWidth={1}
+                  filter={`url(#${negShadowId})`}
+                />
+                <text
+                  x={x}
+                  y={y}
+                  textAnchor="middle"
+                  dominantBaseline="middle"
+                  fontSize={13}
+                  fontWeight="600"
+                  fill={textFill}
+                  style={{ pointerEvents: 'none' }}
                 >
-                  <rect
-                    x={x - pw / 2}
-                    y={y - PILL_HEIGHT / 2}
-                    width={pw}
-                    height={PILL_HEIGHT}
-                    rx={PILL_RADIUS}
-                    fill={fill}
-                    stroke={stroke}
-                    strokeWidth={1}
-                    filter={`url(#${negShadowId})`}
-                  />
-                  <text
-                    x={x}
-                    y={y}
-                    textAnchor="middle"
-                    dominantBaseline="middle"
-                    fontSize={13}
-                    fontWeight="600"
-                    fill={textFill}
-                    style={{ pointerEvents: 'none' }}
-                  >
-                    {kw.keyword}
-                  </text>
-                </motion.g>
-              );
-            })}
+                  {kw.keyword}
+                </text>
+              </motion.g>
+            );
+          })}
 
-            <AnimatePresence>
-              {selected !== null &&
-                displayedArticles.map((article, i) => {
-                  const { x, y } = newsPos[i];
-                  const title = truncateTitle(article.title);
-                  const pl = x - NEWS_PILL_WIDTH / 2;
-                  const pt = y - NEWS_PILL_HEIGHT / 2;
+          <AnimatePresence>
+            {selected !== null &&
+              displayedArticles.map((article, i) => {
+                const { x, y } = newsPos[i];
+                const title = truncateTitle(article.title);
+                const pl = x - NEWS_PILL_WIDTH / 2;
+                const pt = y - NEWS_PILL_HEIGHT / 2;
 
-                  return (
-                    <motion.g
-                      key={`news-${article.articleId}`}
-                      role="button"
-                      tabIndex={0}
-                      initial={{ opacity: 0, scale: 0.75 }}
-                      animate={{ opacity: 1, scale: 1 }}
-                      exit={{ opacity: 0, scale: 0.75 }}
-                      transition={{
-                        duration: 0.22,
-                        delay: 0.12 + i * 0.05,
-                        ease: 'easeOut',
-                      }}
-                      whileHover={{ scale: 1.04 }}
-                      whileFocus={{ scale: 1.04 }}
-                      style={{
-                        cursor: 'pointer',
-                        transformOrigin: `${x}px ${y}px`,
-                      }}
-                      onClick={(e) => {
+                return (
+                  <motion.g
+                    key={`news-${article.articleId}`}
+                    role="button"
+                    tabIndex={0}
+                    initial={{ opacity: 0, scale: 0.75 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    exit={{ opacity: 0, scale: 0.75 }}
+                    transition={{
+                      duration: 0.22,
+                      delay: 0.12 + i * 0.05,
+                      ease: 'easeOut',
+                    }}
+                    whileHover={{ scale: 1.04 }}
+                    whileFocus={{ scale: 1.04 }}
+                    style={{
+                      cursor: 'pointer',
+                      transformOrigin: `${x}px ${y}px`,
+                    }}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onNewsClick(article.articleId);
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
                         e.stopPropagation();
                         onNewsClick(article.articleId);
-                      }}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault();
-                          e.stopPropagation();
-                          onNewsClick(article.articleId);
-                        }
-                      }}
+                      }
+                    }}
+                  >
+                    <rect
+                      x={pl}
+                      y={pt}
+                      width={NEWS_PILL_WIDTH}
+                      height={NEWS_PILL_HEIGHT}
+                      rx={NEWS_PILL_RADIUS}
+                      fill="white"
+                      stroke={drillStroke}
+                      strokeWidth={1}
+                      filter={`url(#${newsShadowId})`}
+                    />
+                    <svg
+                      x={pl + 8}
+                      y={y - NEWS_ICON_SIZE / 2}
+                      width={NEWS_ICON_SIZE}
+                      height={NEWS_ICON_SIZE}
+                      style={{ pointerEvents: 'none', overflow: 'visible' }}
                     >
-                      <rect
-                        x={pl}
-                        y={pt}
-                        width={NEWS_PILL_WIDTH}
-                        height={NEWS_PILL_HEIGHT}
-                        rx={NEWS_PILL_RADIUS}
-                        fill="white"
-                        stroke={drillStroke}
-                        strokeWidth={1}
-                        filter={`url(#${newsShadowId})`}
-                      />
-                      <svg
-                        x={pl + 8}
-                        y={y - NEWS_ICON_SIZE / 2}
+                      <IoDocumentTextOutline
                         width={NEWS_ICON_SIZE}
                         height={NEWS_ICON_SIZE}
-                        style={{ pointerEvents: 'none', overflow: 'visible' }}
-                      >
-                        <IoDocumentTextOutline
-                          width={NEWS_ICON_SIZE}
-                          height={NEWS_ICON_SIZE}
-                          color={drillAccent}
-                        />
-                      </svg>
-                      <text
-                        x={pl + 8 + NEWS_ICON_SIZE + 5}
-                        y={y + 0.5}
-                        dominantBaseline="middle"
-                        fontSize={11}
-                        fontWeight="500"
-                        fill="#374151"
-                        style={{ pointerEvents: 'none' }}
-                      >
-                        {title}
-                      </text>
-                    </motion.g>
-                  );
-                })}
-            </AnimatePresence>
-          </Svg>
-        </BlurContent>
-        {isEmpty && (
-          <EmptyOverlay>
-            <IoCalendarOutline size={36} color="#9ca3af" />
-            <Text size="xs" weight="bold" variant="#62676d">
-              해당 날짜에 생성된 키워드가 없어요!
-            </Text>
-          </EmptyOverlay>
-        )}
-      </Container>
-    </>
+                        color={drillAccent}
+                      />
+                    </svg>
+                    <text
+                      x={pl + 8 + NEWS_ICON_SIZE + 5}
+                      y={y + 0.5}
+                      dominantBaseline="middle"
+                      fontSize={11}
+                      fontWeight="500"
+                      fill="#374151"
+                      style={{ pointerEvents: 'none' }}
+                    >
+                      {title}
+                    </text>
+                  </motion.g>
+                );
+              })}
+          </AnimatePresence>
+        </Svg>
+      </BlurContent>
+      {isEmpty && (
+        <EmptyOverlay>
+          <IoCalendarOutline size={36} color="#9ca3af" />
+          <Text size="xs" weight="bold" variant="#62676d">
+            해당 날짜에 생성된 키워드가 없어요!
+          </Text>
+        </EmptyOverlay>
+      )}
+    </Container>
   );
 }
-
-const BubbleMapHeader = styled.div`
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 6px;
-`;
 
 const Container = styled.div`
   position: relative;

--- a/src/components/Detail/KeywordBubbleMap/index.tsx
+++ b/src/components/Detail/KeywordBubbleMap/index.tsx
@@ -236,7 +236,7 @@ export default function KeywordBubbleMap({
                   y={y}
                   textAnchor="middle"
                   dominantBaseline="middle"
-                  fontSize={13}
+                  fontSize={12}
                   fontWeight="600"
                   fill={textFill}
                   style={{ pointerEvents: 'none' }}
@@ -314,7 +314,7 @@ export default function KeywordBubbleMap({
                   y={y}
                   textAnchor="middle"
                   dominantBaseline="middle"
-                  fontSize={13}
+                  fontSize={12}
                   fontWeight="600"
                   fill={textFill}
                   style={{ pointerEvents: 'none' }}

--- a/src/components/Detail/KeywordBubbleMap/index.tsx
+++ b/src/components/Detail/KeywordBubbleMap/index.tsx
@@ -28,7 +28,7 @@ import {
   calcBubblePositions,
   calcNewsOrbit,
   calcNewsPositions,
-  clampOrbit,
+  calcKeywordOrbit,
   pillWidth,
   truncateTitle,
 } from './positions';
@@ -58,20 +58,26 @@ export default function KeywordBubbleMap({
     null
   );
 
-  const posW = (positiveRatio / 100) * SVG_WIDTH;
-  const negW = (negativeRatio / 100) * SVG_WIDTH;
-  const posCX = posW / 2;
-  const negCX = posW + negW / 2;
+  const posSectionWidth = (positiveRatio / 100) * SVG_WIDTH;
+  const negSectionWidth = (negativeRatio / 100) * SVG_WIDTH;
+  const posCX = posSectionWidth / 2;
+  const negCX = posSectionWidth + negSectionWidth / 2;
 
   const posPos = calcBubblePositions(
     positiveKeywords.length,
     posCX,
-    clampOrbit(posW)
+    calcKeywordOrbit(
+      posSectionWidth,
+      positiveKeywords.map((kw) => kw.keyword)
+    )
   );
   const negPos = calcBubblePositions(
     negativeKeywords.length,
     negCX,
-    clampOrbit(negW)
+    calcKeywordOrbit(
+      negSectionWidth,
+      negativeKeywords.map((kw) => kw.keyword)
+    )
   );
 
   const displayedArticles = selected?.articles.slice(0, 5) ?? [];

--- a/src/components/Detail/KeywordBubbleMap/index.tsx
+++ b/src/components/Detail/KeywordBubbleMap/index.tsx
@@ -345,8 +345,8 @@ export default function KeywordBubbleMap({
               displayedArticles.map((article, i) => {
                 const { x, y } = newsPos[i];
                 const title = newsTitles[i];
-                const newsPillWidth = newsPillWidths[i];
-                const pl = x - newsPillWidth / 2;
+                const currentNewsPillWidth = newsPillWidths[i];
+                const pl = x - currentNewsPillWidth / 2;
                 const pt = y - NEWS_PILL_HEIGHT / 2;
 
                 return (
@@ -383,7 +383,7 @@ export default function KeywordBubbleMap({
                     <rect
                       x={pl}
                       y={pt}
-                      width={newsPillWidth}
+                      width={currentNewsPillWidth}
                       height={NEWS_PILL_HEIGHT}
                       rx={NEWS_PILL_RADIUS}
                       fill="white"

--- a/src/components/Detail/KeywordBubbleMap/positions.ts
+++ b/src/components/Detail/KeywordBubbleMap/positions.ts
@@ -19,7 +19,7 @@ const ANGLES_5 = [
 ];
 
 export function pillWidth(text: string): number {
-  return Math.max(56, text.length * 13 + 20);
+  return Math.max(56, text.length * 10 + 24);
 }
 
 export function calcBubblePositions(count: number, cx: number, orbitR: number) {

--- a/src/components/Detail/KeywordBubbleMap/positions.ts
+++ b/src/components/Detail/KeywordBubbleMap/positions.ts
@@ -22,14 +22,17 @@ export function pillWidth(text: string): number {
   return Math.max(56, text.length * 10 + 24);
 }
 
+function getBubbleAngles(count: number): number[] {
+  return count === 5
+    ? ANGLES_5
+    : Array.from(
+        { length: count },
+        (_, i) => ((2 * Math.PI) / Math.max(count, 1)) * i - Math.PI / 2
+      );
+}
+
 export function calcBubblePositions(count: number, cx: number, orbitR: number) {
-  const angles =
-    count === 5
-      ? ANGLES_5
-      : Array.from(
-          { length: count },
-          (_, i) => ((2 * Math.PI) / Math.max(count, 1)) * i - Math.PI / 2
-        );
+  const angles = getBubbleAngles(count);
   return angles.map((angle) => ({
     x: cx + orbitR * Math.cos(angle),
     y: SVG_CENTER_Y + orbitR * Math.sin(angle),
@@ -43,6 +46,7 @@ export function calcBubblePositions(count: number, cx: number, orbitR: number) {
  */
 export function calcNewsOrbit(keywordText: string): number {
   const pw = pillWidth(keywordText);
+  // 여백값 12, 2도 나중에 상수로 빼서 관리하기
   const minByHoriz = pw / 2 + NEWS_PILL_WIDTH / 2 + 12;
   const maxByBounds = SVG_CENTER_Y - NEWS_PILL_HEIGHT / 2 - 2;
   return Math.min(maxByBounds, Math.max(NEWS_ORBIT, minByHoriz));
@@ -84,15 +88,36 @@ export function calcNewsPositions(count: number, orbit: number) {
   }));
 }
 
-export function clampOrbit(sectionWidth: number): number {
-  return Math.max(
-    0,
-    Math.min(
-      MAX_ORBIT,
-      sectionWidth / 2 - PILL_HEIGHT - 8,
-      SVG_CENTER_Y - PILL_HEIGHT - 14
-    )
-  );
+export function calcKeywordOrbit(
+  sentiSectionWidth: number,
+  keywords: string[] = []
+): number {
+  const count = keywords.length;
+
+  if (count === 0) return MAX_ORBIT;
+  const maxPw = Math.max(...keywords.map(pillWidth));
+  const halfSec = sentiSectionWidth / 2;
+  const margin = 4;
+
+  const angles = getBubbleAngles(count);
+
+  let upperBound = Infinity;
+  for (const angle of angles) {
+    const absC = Math.abs(Math.cos(angle));
+    const absS = Math.abs(Math.sin(angle));
+    upperBound = Math.min(upperBound, (halfSec - maxPw / 2 - margin) / absC);
+    upperBound = Math.min(
+      upperBound,
+      (SVG_CENTER_Y - PILL_HEIGHT / 2 - margin) / absS
+    );
+  }
+  if (!isFinite(upperBound)) upperBound = halfSec - maxPw / 2 - margin;
+
+  if (count <= 1) return Math.max(0, Math.min(MAX_ORBIT, upperBound));
+  const minAngleGap = count === 5 ? (7 * Math.PI) / 20 : (2 * Math.PI) / count;
+  const minByPills = (maxPw + 8) / (2 * Math.sin(minAngleGap / 2));
+
+  return Math.max(0, Math.min(upperBound, Math.max(MAX_ORBIT, minByPills)));
 }
 
 export function truncateTitle(title: string): string {

--- a/src/components/Detail/KeywordBubbleMap/positions.ts
+++ b/src/components/Detail/KeywordBubbleMap/positions.ts
@@ -2,6 +2,7 @@ import {
   SVG_CENTER_Y,
   SVG_WIDTH,
   MAX_ORBIT,
+  NEWS_ICON_SIZE,
   NEWS_MAX_CHARS,
   NEWS_ORBIT,
   NEWS_PILL_HEIGHT,
@@ -19,6 +20,17 @@ const ANGLES_5 = [
 
 export function pillWidth(text: string): number {
   return Math.max(56, text.length * 10 + 24);
+}
+
+export function newsPillWidth(title: string): number {
+  let textWidth = 0;
+  for (const ch of title) {
+    const code = ch.codePointAt(0) ?? 0;
+    const isKorean =
+      (code >= 0xac00 && code <= 0xd7a3) || (code >= 0x4e00 && code <= 0x9fff);
+    textWidth += isKorean ? 10 : 6;
+  }
+  return Math.max(100, NEWS_ICON_SIZE + textWidth + 8);
 }
 
 function getBubbleAngles(count: number): number[] {
@@ -43,10 +55,13 @@ export function calcBubblePositions(count: number, cx: number, orbitR: number) {
  * - 수평 최솟값: pill 너비/2 + gap + 뉴스 카드 너비/2 (pill과 뉴스 카드가 겹치지 않도록)
  * - 상한: SVG 세로 경계를 벗어나지 않도록 제한
  */
-export function calcNewsOrbit(keywordText: string): number {
+export function calcNewsOrbit(
+  keywordText: string,
+  maxNewsPillWidth = NEWS_PILL_WIDTH
+): number {
   const pw = pillWidth(keywordText);
   // 여백값 12, 2도 나중에 상수로 빼서 관리하기
-  const minByHoriz = pw / 2 + NEWS_PILL_WIDTH / 2 + 12;
+  const minByHoriz = pw / 2 + maxNewsPillWidth / 2 + 12;
   const maxByBounds = SVG_CENTER_Y - NEWS_PILL_HEIGHT / 2 - 2;
   return Math.min(maxByBounds, Math.max(NEWS_ORBIT, minByHoriz));
 }

--- a/src/components/Detail/KeywordBubbleMap/positions.ts
+++ b/src/components/Detail/KeywordBubbleMap/positions.ts
@@ -30,7 +30,7 @@ export function newsPillWidth(title: string): number {
       (code >= 0xac00 && code <= 0xd7a3) || (code >= 0x4e00 && code <= 0x9fff);
     textWidth += isKorean ? 10 : 6;
   }
-  return Math.max(100, NEWS_ICON_SIZE + textWidth + 8);
+  return Math.max(100, 8 + NEWS_ICON_SIZE + 5 + textWidth + 8);
 }
 
 function getBubbleAngles(count: number): number[] {

--- a/src/components/Detail/KeywordBubbleMap/positions.ts
+++ b/src/components/Detail/KeywordBubbleMap/positions.ts
@@ -9,7 +9,6 @@ import {
   PILL_HEIGHT,
 } from './constants';
 
-// count=5 공통 각도: 하단 쌍을 45°/135°로 넓혀 좌하/우하 간격 확보 (cf - 정오각형은 72° 간격)
 const ANGLES_5 = [
   -Math.PI / 2,
   -Math.PI / 10,
@@ -59,33 +58,73 @@ export function calcNewsPositions(count: number, orbit: number) {
     return [{ x: cx, y: SVG_CENTER_Y + orbit * Math.sin(Math.PI / 6) }];
   }
   if (count === 2) {
-    const r = Math.PI / 6;
+    const angle = Math.PI / 6;
     return [
-      { x: cx - orbit * Math.cos(r), y: SVG_CENTER_Y + orbit * Math.sin(r) },
-      { x: cx + orbit * Math.cos(r), y: SVG_CENTER_Y + orbit * Math.sin(r) },
+      {
+        x: cx - orbit * Math.cos(angle),
+        y: SVG_CENTER_Y + orbit * Math.sin(angle),
+      },
+      {
+        x: cx + orbit * Math.cos(angle),
+        y: SVG_CENTER_Y + orbit * Math.sin(angle),
+      },
     ];
   }
   if (count === 3) {
-    const r = Math.PI / 6;
+    const angle = Math.PI / 6;
     return [
-      { x: cx, y: SVG_CENTER_Y - orbit * Math.sin(r) },
-      { x: cx - orbit * Math.cos(r), y: SVG_CENTER_Y + orbit * Math.sin(r) },
-      { x: cx + orbit * Math.cos(r), y: SVG_CENTER_Y + orbit * Math.sin(r) },
+      { x: cx, y: SVG_CENTER_Y - orbit * Math.sin(angle) },
+      {
+        x: cx - orbit * Math.cos(angle),
+        y: SVG_CENTER_Y + orbit * Math.sin(angle),
+      },
+      {
+        x: cx + orbit * Math.cos(angle),
+        y: SVG_CENTER_Y + orbit * Math.sin(angle),
+      },
     ];
   }
   if (count === 4) {
-    return Array.from({ length: 4 }, (_, i) => {
-      const angle = -Math.PI / 4 + (Math.PI / 2) * i;
-      return {
+    const angle = Math.PI / 6;
+    return [
+      {
+        x: cx - orbit * Math.cos(angle),
+        y: SVG_CENTER_Y - orbit * Math.sin(angle),
+      },
+      {
+        x: cx + orbit * Math.cos(angle),
+        y: SVG_CENTER_Y - orbit * Math.sin(angle),
+      },
+      {
+        x: cx - orbit * Math.cos(angle),
+        y: SVG_CENTER_Y + orbit * Math.sin(angle),
+      },
+      {
         x: cx + orbit * Math.cos(angle),
         y: SVG_CENTER_Y + orbit * Math.sin(angle),
-      };
-    });
+      },
+    ];
   }
-  return ANGLES_5.map((angle) => ({
-    x: cx + orbit * Math.cos(angle),
-    y: SVG_CENTER_Y + orbit * Math.sin(angle),
-  }));
+  const bottomAngle = Math.PI / 5;
+  return [
+    { x: cx, y: SVG_CENTER_Y - orbit * 0.8 },
+    {
+      x: cx + orbit * Math.cos(Math.PI / 10),
+      y: SVG_CENTER_Y - orbit * Math.sin(Math.PI / 10),
+    },
+    {
+      x: cx + orbit * Math.cos(bottomAngle),
+      y: SVG_CENTER_Y + orbit * Math.sin(bottomAngle),
+    },
+    {
+      x: cx - orbit * Math.cos(bottomAngle),
+      y: SVG_CENTER_Y + orbit * Math.sin(bottomAngle),
+    },
+    {
+      x: cx - orbit * Math.cos(Math.PI / 10),
+      y: SVG_CENTER_Y - orbit * Math.sin(Math.PI / 10),
+    },
+  ];
 }
 
 export function calcKeywordOrbit(

--- a/src/mocks/detailHandlers.ts
+++ b/src/mocks/detailHandlers.ts
@@ -856,6 +856,16 @@ export const detailHandlers = [
     ({ request }) => {
       const url = new URL(request.url);
       const date = url.searchParams.get('date') ?? '2025-05-29';
+
+      const emptyDates = ['2026-06-07', '2026-06-08', '2026-06-26'];
+      if (emptyDates.includes(date)) {
+        return HttpResponse.json({
+          code: '200 OK',
+          message: '키워드/관련 아티클 목록을 성공적으로 조회하였습니다.',
+          content: { keywords: [] },
+        });
+      }
+
       const keywords = mockKeywordsData.map((kw) => ({ ...kw, date }));
 
       return HttpResponse.json({

--- a/src/mocks/detailHandlers.ts
+++ b/src/mocks/detailHandlers.ts
@@ -7,6 +7,7 @@ import { getRealTimeStreamPath } from '@/api/hooks/useGetRealTimeStream';
 import { getArticleSummaryTickerPath } from '@/api/hooks/useGetArticleSummaryTicker';
 import { getTickerKeywordsPath } from '@/api/hooks/useGetTickerKeywords';
 import { TickerRealTimeStreamResponse } from '@/types';
+import { mockKeywordsData } from './mockKeywordsData';
 
 const mockNewsData = [
   {
@@ -291,97 +292,6 @@ const realTimeGraphData = {
 const mockRealGraphData = generateGraphDataWithChangeRate(
   baseMockRealGraphData
 );
-
-const mockKeywordsData = [
-  {
-    keyword: '실적호조',
-    articles: [
-      { articleId: '1', title: '삼성전자 실적 호조로 주가 급등' },
-      { articleId: '2', title: '애플 신제품 출시 기대감 확산' },
-      { articleId: '3', title: 'AI 반도체 수요 폭발적 증가세' },
-    ],
-    sentiment: 1,
-    date: '2025-05-29',
-  },
-  {
-    keyword: 'AI반도체',
-    articles: [{ articleId: '3', title: 'AI 반도체 수요 폭발적 증가세' }],
-    sentiment: 1,
-    date: '2025-05-29',
-  },
-  {
-    keyword: '신제품기대 완전 기대',
-    articles: [
-      { articleId: '2', title: '애플 신제품 출시 기대감 확산' },
-      { articleId: '1', title: '삼성전자 실적 호조로 주가 급등' },
-      { articleId: '5', title: '2분기 실적 시장 기대치 상회' },
-      { articleId: '3', title: 'AI 반도체 수요 폭발적 증가세' },
-      { articleId: '4', title: '코스피 외국인 순매수 전환' },
-    ],
-    sentiment: 1,
-    date: '2025-05-29',
-  },
-  {
-    keyword: '어닝서프라이즈',
-    articles: [
-      { articleId: '5', title: '2분기 실적 시장 기대치 상회' },
-      { articleId: '3', title: 'AI 반도체 수요 폭발적 증가세' },
-      { articleId: '1', title: '삼성전자 실적 호조로 주가 급등' },
-      { articleId: '2', title: '애플 신제품 출시 기대감 확산' },
-    ],
-    sentiment: 1,
-  },
-  {
-    keyword: '데이터센터 전력 확보',
-    articles: [],
-    sentiment: 1,
-    date: '2025-05-29',
-  },
-  {
-    keyword: '인공지능 인프라센터 건축',
-    articles: [
-      { articleId: '1', title: '금리 인상 우려에 증시 하락' },
-      { articleId: '5', title: '인플레이션 예상치 웃돌아' },
-      { articleId: '3', title: '달러 강세 수출주 압박' },
-    ],
-    sentiment: -1,
-    date: '2025-05-29',
-  },
-  {
-    keyword: '달러강세',
-    articles: [
-      { articleId: '3', title: '달러 강세 수출주 압박' },
-      { articleId: '1', title: '금리 인상 우려에 증시 하락' },
-    ],
-    sentiment: -1,
-    date: '2025-05-29',
-  },
-  {
-    keyword: '공급 과잉 우려',
-    articles: [
-      { articleId: '6', title: '반도체 공급 과잉 우려 지속' },
-      { articleId: '4', title: '중국 경기 침체 공포 확산' },
-      { articleId: '5', title: '인플레이션 예상치 웃돌아' },
-    ],
-    sentiment: -1,
-    date: '2025-05-29',
-  },
-  {
-    keyword: '인플레이션',
-    articles: [
-      { articleId: '5', title: '인플레이션 예상치 웃돌아' },
-      { articleId: '1', title: '금리 인상 우려에 증시 하락' },
-    ],
-    sentiment: -1,
-    date: '2025-05-29',
-  },
-  {
-    keyword: '규제리스크 우려',
-    articles: [],
-    sentiment: -1,
-    date: '2025-05-29',
-  },
-];
 
 const mockArticleSummary = {
   tickerId: '0-d-q-8b-95n',

--- a/src/mocks/detailHandlers.ts
+++ b/src/mocks/detailHandlers.ts
@@ -310,7 +310,7 @@ const mockKeywordsData = [
     date: '2025-05-29',
   },
   {
-    keyword: '신제품기대',
+    keyword: '신제품기대 완전 기대',
     articles: [
       { articleId: '2', title: '애플 신제품 출시 기대감 확산' },
       { articleId: '1', title: '삼성전자 실적 호조로 주가 급등' },
@@ -332,13 +332,13 @@ const mockKeywordsData = [
     sentiment: 1,
   },
   {
-    keyword: '배당확대',
+    keyword: '데이터센터 전력 확보',
     articles: [],
     sentiment: 1,
     date: '2025-05-29',
   },
   {
-    keyword: '금리인상',
+    keyword: '인공지능 인프라센터 건축',
     articles: [
       { articleId: '1', title: '금리 인상 우려에 증시 하락' },
       { articleId: '5', title: '인플레이션 예상치 웃돌아' },
@@ -357,7 +357,7 @@ const mockKeywordsData = [
     date: '2025-05-29',
   },
   {
-    keyword: '공급과잉',
+    keyword: '공급 과잉 우려',
     articles: [
       { articleId: '6', title: '반도체 공급 과잉 우려 지속' },
       { articleId: '4', title: '중국 경기 침체 공포 확산' },
@@ -376,7 +376,7 @@ const mockKeywordsData = [
     date: '2025-05-29',
   },
   {
-    keyword: '규제리스크',
+    keyword: '규제리스크 우려',
     articles: [],
     sentiment: -1,
     date: '2025-05-29',

--- a/src/mocks/mockKeywordsData.ts
+++ b/src/mocks/mockKeywordsData.ts
@@ -1,0 +1,93 @@
+import type { KeywordsWithArticleResponse } from '@/types';
+
+export const mockKeywordsData: KeywordsWithArticleResponse[] = [
+  {
+    keyword: '실적호조',
+    articles: [
+      { articleId: '1', title: '삼성전자 실적 호조로 주가 급등' },
+      { articleId: '2', title: '애플 신제품 출시 기대감 확산' },
+      { articleId: '3', title: 'AI 반도체 수요 폭발적 증가세' },
+    ],
+    sentiment: 1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: 'AI반도체',
+    articles: [{ articleId: '3', title: 'AI 반도체 수요 폭발적 증가세' }],
+    sentiment: 1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: '신제품기대 완전 기대',
+    articles: [
+      { articleId: '2', title: '애플 신제품 출시 기대감 확산' },
+      { articleId: '1', title: '삼성전자 실적 호조로 주가 급등' },
+      { articleId: '5', title: '2분기 실적 시장 기대치 상회' },
+      { articleId: '3', title: 'AI 반도체 수요 폭발적 증가세' },
+      { articleId: '4', title: '코스피 외국인 순매수 전환' },
+    ],
+    sentiment: 1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: '어닝서프라이즈',
+    articles: [
+      { articleId: '5', title: '2분기 실적 시장 기대치 상회' },
+      { articleId: '3', title: 'AI 반도체 수요 폭발적 증가세' },
+      { articleId: '1', title: '삼성전자 실적 호조로 주가 급등' },
+      { articleId: '2', title: '애플 신제품 출시 기대감 확산' },
+    ],
+    sentiment: 1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: '데이터센터 전력 확보',
+    articles: [],
+    sentiment: 1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: '인공지능 인프라센터 건축',
+    articles: [
+      { articleId: '1', title: '금리 인상 우려에 증시 하락' },
+      { articleId: '5', title: '인플레이션 예상치 웃돌아' },
+      { articleId: '3', title: '달러 강세 수출주 압박' },
+    ],
+    sentiment: -1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: '달러강세',
+    articles: [
+      { articleId: '3', title: '달러 강세 수출주 압박' },
+      { articleId: '1', title: '금리 인상 우려에 증시 하락' },
+    ],
+    sentiment: -1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: '공급 과잉 우려',
+    articles: [
+      { articleId: '6', title: '반도체 공급 과잉 우려 지속' },
+      { articleId: '4', title: '중국 경기 침체 공포 확산' },
+      { articleId: '5', title: '인플레이션 예상치 웃돌아' },
+    ],
+    sentiment: -1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: '인플레이션',
+    articles: [
+      { articleId: '5', title: '인플레이션 예상치 웃돌아' },
+      { articleId: '1', title: '금리 인상 우려에 증시 하락' },
+    ],
+    sentiment: -1,
+    date: '2025-05-29',
+  },
+  {
+    keyword: '규제리스크 우려',
+    articles: [],
+    sentiment: -1,
+    date: '2025-05-29',
+  },
+];

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -24,6 +24,7 @@ import { Text } from '@/components/common/typography/Text';
 import LoginModal from '@/components/common/Modal/LoginModal';
 import ArticleSection from '@/components/Detail/ArticleSection';
 import KeywordBubbleMap from '@/components/Detail/KeywordBubbleMap';
+import { mockKeywordsData } from '@/mocks/mockKeywordsData';
 
 import SummaryModal from '@/components/Detail/ABTest/GroupA/SummaryModal';
 import TickerHeaderA from '@/components/Detail/ABTest/GroupA/TickerHeader';
@@ -111,12 +112,7 @@ export default function DetailPage() {
   );
   const isKeywordsEmpty = rawKeywords.length === 0;
 
-  const [savedKeywords, setSavedKeywords] = useState(rawKeywords);
-  useEffect(() => {
-    if (rawKeywords.length > 0) setSavedKeywords(rawKeywords);
-  }, [rawKeywords]);
-
-  const keywords = isKeywordsEmpty ? savedKeywords : rawKeywords;
+  const keywords = isKeywordsEmpty ? mockKeywordsData : rawKeywords;
   const positiveKeywords = keywords.filter((k) => k.sentiment === 1);
   const negativeKeywords = keywords.filter((k) => k.sentiment !== 1);
   const total = positiveKeywords.length + negativeKeywords.length;

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -92,13 +92,14 @@ export default function DetailPage() {
     }
     setSummaryEnabled(true);
   };
-  const { data: keywordsResponse } = useGetTickerKeywords(
-    id,
-    selectedDate,
-    keywordCount,
-    articleCount,
-    titleLength
-  );
+  const { data: keywordsResponse, isLoading: isKeywordsLoading } =
+    useGetTickerKeywords(
+      id,
+      selectedDate,
+      keywordCount,
+      articleCount,
+      titleLength
+    );
 
   const tickerData = tickerResponse?.content;
   const realGraphData = realGraphResponse?.content;
@@ -110,7 +111,7 @@ export default function DetailPage() {
     () => keywordsResponse?.content?.keywords ?? [],
     [keywordsResponse]
   );
-  const isKeywordsEmpty = rawKeywords.length === 0;
+  const isKeywordsEmpty = !isKeywordsLoading && rawKeywords.length === 0;
 
   const keywords = isKeywordsEmpty ? mockKeywordsData : rawKeywords;
   const positiveKeywords = keywords.filter((k) => k.sentiment === 1);

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -16,8 +16,11 @@ import useIsMobile from '@/hooks/useIsMobile';
 import useAuth from '@/hooks/useAuth';
 
 import { getDetailABVariant } from '@/utils/abTest';
+import { formatMonthDay } from '@/utils/formatDate';
 
 import Loading from '@/components/common/Layout/Loading';
+import { Paragraph } from '@/components/common/typography/Paragraph';
+import { Text } from '@/components/common/typography/Text';
 import LoginModal from '@/components/common/Modal/LoginModal';
 import ArticleSection from '@/components/Detail/ArticleSection';
 import KeywordBubbleMap from '@/components/Detail/KeywordBubbleMap';
@@ -31,6 +34,7 @@ import DailySummary from '@/components/Detail/ABTest/GroupB/DailySummary';
 import TickerHeaderB from '@/components/Detail/ABTest/GroupB/TickerHeader';
 import TickerPriceSectionB from '@/components/Detail/ABTest/GroupB/TickerPriceSection';
 import ChartSectionB from '@/components/Detail/ABTest/GroupB/ChartSection';
+import DatePickerButton from '@/components/common/DatePickerButton';
 
 export default function DetailPage() {
   const variant = getDetailABVariant();
@@ -233,16 +237,32 @@ export default function DetailPage() {
   };
 
   const keywordBubbleMap = (variant: 'A' | 'B') => (
-    <KeywordBubbleMap
-      positiveRatio={positiveRatio}
-      negativeRatio={negativeRatio}
-      positiveKeywords={positiveKeywords}
-      negativeKeywords={negativeKeywords}
-      date={selectedDate}
-      isEmpty={isKeywordsEmpty}
-      onNewsClick={(articleId) => navigate(`/news/${articleId}`)}
-      {...(variant === 'B' && { onDateChange: setSelectedDate })}
-    />
+    <>
+      <SummarySectionHeader>
+        <Paragraph size={isMobile ? 'xs' : 's'} weight="bold">
+          <Text size={isMobile ? 'xs' : 's'} weight="bold" variant="#2d70d3">
+            {formatMonthDay(selectedDate)}
+          </Text>
+          의 뉴스 요약
+        </Paragraph>
+        {variant === 'B' && (
+          <DatePickerButton
+            selectedDate={selectedDate}
+            onDateChange={setSelectedDate}
+            popupZIndex={9}
+          />
+        )}
+      </SummarySectionHeader>
+      <KeywordBubbleMap
+        positiveRatio={positiveRatio}
+        negativeRatio={negativeRatio}
+        positiveKeywords={positiveKeywords}
+        negativeKeywords={negativeKeywords}
+        date={selectedDate}
+        isEmpty={isKeywordsEmpty}
+        onNewsClick={(articleId) => navigate(`/news/${articleId}`)}
+      />
+    </>
   );
 
   return (
@@ -333,6 +353,14 @@ const Wrapper = styled.div<{ $variant: 'A' | 'B' }>`
     gap: 18px;
     padding: 12px 0;
   }
+`;
+
+const SummarySectionHeader = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 6px;
 `;
 
 const ErrorMessage = styled.div`

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useParams, useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -101,7 +101,18 @@ export default function DetailPage() {
   const summaryData = summaryResponse?.content ?? null;
   const articles = tickerData?.detailData.article;
 
-  const keywords = keywordsResponse?.content?.keywords ?? [];
+  const rawKeywords = useMemo(
+    () => keywordsResponse?.content?.keywords ?? [],
+    [keywordsResponse]
+  );
+  const isKeywordsEmpty = rawKeywords.length === 0;
+
+  const [savedKeywords, setSavedKeywords] = useState(rawKeywords);
+  useEffect(() => {
+    if (rawKeywords.length > 0) setSavedKeywords(rawKeywords);
+  }, [rawKeywords]);
+
+  const keywords = isKeywordsEmpty ? savedKeywords : rawKeywords;
   const positiveKeywords = keywords.filter((k) => k.sentiment === 1);
   const negativeKeywords = keywords.filter((k) => k.sentiment !== 1);
   const total = positiveKeywords.length + negativeKeywords.length;
@@ -221,18 +232,18 @@ export default function DetailPage() {
     onLikeClick: handleLikeClick,
   };
 
-  const keywordBubbleMap = (variant: 'A' | 'B') =>
-    keywords.length > 0 && (
-      <KeywordBubbleMap
-        positiveRatio={positiveRatio}
-        negativeRatio={negativeRatio}
-        positiveKeywords={positiveKeywords}
-        negativeKeywords={negativeKeywords}
-        date={selectedDate}
-        onNewsClick={(articleId) => navigate(`/news/${articleId}`)}
-        {...(variant === 'B' && { onDateChange: setSelectedDate })}
-      />
-    );
+  const keywordBubbleMap = (variant: 'A' | 'B') => (
+    <KeywordBubbleMap
+      positiveRatio={positiveRatio}
+      negativeRatio={negativeRatio}
+      positiveKeywords={positiveKeywords}
+      negativeKeywords={negativeKeywords}
+      date={selectedDate}
+      isEmpty={isKeywordsEmpty}
+      onNewsClick={(articleId) => navigate(`/news/${articleId}`)}
+      {...(variant === 'B' && { onDateChange: setSelectedDate })}
+    />
+  );
 
   return (
     <>


### PR DESCRIPTION
### ✨ 작업 내용
- [x] keywordPill 섹션 경계 초과 및 겹치는 문제 수정 (`calcKeywordOrbit` 동적 계산)
- [x] 뉴스 카드 count=4,5 가로 간격 부족으로 인한 겹침 수정
- [x] 뉴스 카드 너비를 제목 텍스트 기반 동적 계산으로 교체 (`newsPillWidth`)
- [x] 키워드 없는 날짜 진입 시 KeywordBubbleMap 초기값 mock 데이터로 교체
- [x] `mockKeywordsData`를 `detailHandlers.ts`에서 분리해 별도 파일로 추출
- [x] `getBubbleAngles` 헬퍼 추출로 중복 제거

---
### ✨ 참고 사항

**이슈 1: keywordPill이 겹쳐지는 경우 발생**
- 원인
  1. `clampOrbit`이 섹션 너비만 받고 키워드 내용을 무시한 채 `MAX_ORBIT(74)` 고정값을 반환 → 긴 pill끼리 orbit이 좁아 겹침
  2. 가로 경계 계산에 `PILL_HEIGHT(30)`을 사용 → 실제 pill 너비가 아닌 높이로 경계를 판단해 가로로 넘침
- 해결 방안
  1. `calcKeywordOrbit`으로 교체 — 키워드 텍스트 길이로 `maxPw`를 계산해 orbit 하한(`minByPills`) 동적 산정
  2. 가로 경계 계산을 `PILL_HEIGHT/2` → `maxPw/2`로 교체, 모든 각도를 순회하며 각 pill의 실제 가로/세로 이동량으로 `upperBound` 계산

**이슈 2: 뉴스 pill 내 우측 여백 불균일**
- 원인
  1. 모든 뉴스 카드에 `NEWS_PILL_WIDTH(200)` 고정 너비 적용 → 영문 비중이 높은 제목은 실제 텍스트가 짧아 오른쪽에 빈 공간 발생
- 해결 방안
  1. `newsPillWidth(title)` 함수 추가 — 한글 10px / 영문 6px로 문자별 너비를 추정하고 아이콘 영역을 합산해 pill 너비를 동적 계산
  2. `calcNewsOrbit`에 `maxNewsPillWidth` 파라미터 추가 — keyword pill ↔ 뉴스 카드 간 최소 간격 계산 시 실제 최대 너비 반영
- 참고
  - SVG `getBBox()`로 실제 렌더링된 텍스트 너비를 정확히 측정하는 방법도 있으나, 화면에 먼저 그린 뒤 크기를 측정해 다시 그려야 하는 구조라 깜빡임이 발생할 수 있어 news 제목 기반으로 너비를 추정하는 방식 채택함

---

### ⏰ 현재 버그

---

### ✏ Git Close
