### PR TITLE
[Articker - 47] 로그인 후 뒤로가기 시 /callback 흰 화면 및 인증 상태 초기화 문제 수정

### DIFF
--- a/src/pages/Callback/index.tsx
+++ b/src/pages/Callback/index.tsx
@@ -23,13 +23,13 @@ export default function CallbackPage() {
     if (!state || state !== storedState) {
       console.error('OAuth state mismatch - possible CSRF attack');
       sessionStorage.removeItem('oauthState');
-      window.location.href = '/';
+      window.location.replace('/');
       return;
     }
     sessionStorage.removeItem('oauthState');
 
     if (!code) {
-      window.location.href = '/';
+      window.location.replace('/');
       return;
     }
     isOAuthProcessingRef.current = true;
@@ -46,11 +46,11 @@ export default function CallbackPage() {
             queryClient.setQueryData(['userInfo'], userInfoResponse);
             handleLoginSuccess(userInfoResponse.content);
           } catch {
-            window.location.href = '/';
+            window.location.replace('/');
             return;
           }
           if (response.content.isNewUser === true) {
-            window.location.href = '/join';
+            window.location.replace('/join');
             return;
           }
           const redirectPath = localStorage.getItem('redirectPath');
@@ -60,14 +60,14 @@ export default function CallbackPage() {
             !redirectPath.startsWith('//')
           ) {
             localStorage.removeItem('redirectPath');
-            window.location.href = redirectPath;
+            window.location.replace(redirectPath);
           } else {
-            window.location.href = '/';
+            window.location.replace('/');
           }
         },
         onError: (error) => {
           console.error('OAuth login failed:', error);
-          window.location.href = '/';
+          window.location.replace('/');
         },
       }
     );

--- a/src/provider/Auth/index.tsx
+++ b/src/provider/Auth/index.tsx
@@ -13,10 +13,12 @@ interface AuthProviderProps {
   children: React.ReactNode;
 }
 
+const getStoredAuthStatus = () =>
+  localStorage.getItem('isAuthenticated') === 'true';
+
 export default function AuthProvider({ children }: AuthProviderProps) {
-  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(
-    () => localStorage.getItem('isAuthenticated') === 'true'
-  );
+  const [isAuthenticated, setIsAuthenticated] =
+    useState<boolean>(getStoredAuthStatus);
   const [isInitialized, setIsInitialized] = useState<boolean>(false);
   const { mutateAsync: refreshToken } = usePostReissueToken();
   const { mutateAsync: logout } = usePostLogout();
@@ -48,8 +50,7 @@ export default function AuthProvider({ children }: AuthProviderProps) {
   useEffect(() => {
     const handlePageShow = (event: PageTransitionEvent) => {
       if (event.persisted) {
-        const storedAuthStatus =
-          localStorage.getItem('isAuthenticated') === 'true';
+        const storedAuthStatus = getStoredAuthStatus();
         if (storedAuthStatus !== isAuthenticated) {
           document.body.style.visibility = 'hidden';
           window.location.reload();
@@ -73,8 +74,7 @@ export default function AuthProvider({ children }: AuthProviderProps) {
 
   useEffect(() => {
     const initialize = async () => {
-      const savedAuthStatus =
-        localStorage.getItem('isAuthenticated') === 'true';
+      const savedAuthStatus = getStoredAuthStatus();
       if (savedAuthStatus) {
         try {
           await doRefreshToken();

--- a/src/provider/Auth/index.tsx
+++ b/src/provider/Auth/index.tsx
@@ -45,6 +45,20 @@ export default function AuthProvider({ children }: AuthProviderProps) {
     setOnUnauthorized(handleLogout);
   }, [doRefreshToken, handleLogout]);
 
+  useEffect(() => {
+    const handlePageShow = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        const storedAuthStatus =
+          localStorage.getItem('isAuthenticated') === 'true';
+        if (storedAuthStatus !== isAuthenticated) {
+          window.location.reload();
+        }
+      }
+    };
+    window.addEventListener('pageshow', handlePageShow);
+    return () => window.removeEventListener('pageshow', handlePageShow);
+  }, [isAuthenticated]);
+
   const handleLoginSuccess = useCallback(
     async (userInfo: UserInfoResponse) => {
       if (!isAuthenticated) {

--- a/src/provider/Auth/index.tsx
+++ b/src/provider/Auth/index.tsx
@@ -51,6 +51,7 @@ export default function AuthProvider({ children }: AuthProviderProps) {
         const storedAuthStatus =
           localStorage.getItem('isAuthenticated') === 'true';
         if (storedAuthStatus !== isAuthenticated) {
+          document.body.style.visibility = 'hidden';
           window.location.reload();
         }
       }


### PR DESCRIPTION
### ✨ 작업 내용
- [x] 콜백 URL이 히스토리에 남지 않도록 window.location.href를 replace로 변경
- [x] 뒤로가기 시 로그인 이전 페이지가 복원되는 경우 인증 상태 재검증
- [x] 뒤로가기 시 인증 상태 재확인 전 화면 깜빡임 방지

---

### ✨ 참고 사항

**이슈 1: 로그인 후 뒤로가기 시 /callback 흰 화면 노출**
- 원인
  - `window.location.href`로 리다이렉트 시 `/callback?code=...` URL이 히스토리에 추가됨
  - 뒤로가기 시 해당 URL로 돌아오며 `return null`인 CallbackPage가 흰 화면 노출
- 해결 방안
  - `window.location.replace()`로 변경해 콜백 URL을 히스토리에서 교체, 뒤로가기로 접근 불가하도록 수정

**이슈 2: 뒤로가기 시 로그인 이전 상태(미인증, 모달 열림)로 복원**
- 원인
  - 브라우저 BF 캐시가 로그인 이전 페이지를 메모리에 보존
  - 뒤로가기 시 캐시된 React 상태(isAuthenticated: false)가 그대로 복원됨
- 해결 방안
  - `pageshow` 이벤트에서 `event.persisted` 감지 시 localStorage의 인증 상태와 비교해 불일치하면 리로드
  - 리로드 전 `document.body.style.visibility = 'hidden'` 처리로 복원된 화면 깜빡임 방지

---

### ⏰ 현재 버그

---

### ✏ Git Close